### PR TITLE
Removed UTxO limit in fallback DESC algorithm

### DIFF
--- a/src/lib/coinSelection.js
+++ b/src/lib/coinSelection.js
@@ -350,12 +350,7 @@ function select(utxoSelection, outputAmount, limit, minUTxOValue) {
   } catch (e) {
     if (e.message === 'INPUT_LIMIT_EXCEEDED') {
       // Limit reached : Fallback on DescOrdAlgo
-      utxoSelection = descSelect(
-        utxoSelection,
-        outputAmount,
-        limit - utxoSelection.selection.length,
-        minUTxOValue
-      );
+      utxoSelection = descSelect(utxoSelection, outputAmount, minUTxOValue);
     } else {
       throw e;
     }
@@ -418,14 +413,12 @@ function randomSelect(utxoSelection, outputAmount, limit, minUTxOValue) {
  * Select enough UTxO in DESC order to fulfill requested outputs
  * @param {UTxOSelection} utxoSelection - The set of selected/available inputs.
  * @param {Value} outputAmount - Single compiled output qty requested for payment.
- * @param {int} limit - A limit on the number of inputs that can be selected.
  * @param {int} minUTxOValue - Network protocol 'minUTxOValue' current value.
- * @throws INPUT_LIMIT_EXCEEDED if the number of randomly picked inputs exceed 'limit' parameter.
  * @throws INPUTS_EXHAUSTED if all UTxO doesn't hold enough funds to pay for output.
  * @throws MIN_UTXO_ERROR if lovelace change is under 'minUTxOValue' parameter.
  * @return {UTxOSelection} - Successful random utxo selection.
  */
-function descSelect(utxoSelection, outputAmount, limit, minUTxOValue) {
+function descSelect(utxoSelection, outputAmount, minUTxOValue) {
   // Sort UTxO subset in DESC order for required Output unit type
   utxoSelection.subset = utxoSelection.subset.sort((a, b) => {
     return Number(
@@ -435,10 +428,6 @@ function descSelect(utxoSelection, outputAmount, limit, minUTxOValue) {
   });
 
   do {
-    if (limit <= 0) {
-      throw new Error('INPUT_LIMIT_EXCEEDED');
-    }
-
     if (utxoSelection.subset.length <= 0) {
       if (isQtyFulfilled(outputAmount, utxoSelection.amount, 0, 0)) {
         throw new Error('MIN_UTXO_ERROR');
@@ -454,8 +443,6 @@ function descSelect(utxoSelection, outputAmount, limit, minUTxOValue) {
       utxo.output().amount(),
       utxoSelection.amount
     );
-
-    limit--;
   } while (
     !isQtyFulfilled(
       outputAmount,


### PR DESCRIPTION

### Context:
The limit parameter found in the CoinSelection algorithm is an optimization feature aiming to find the right balance between transaction fees & dust management.
The coinselection is actually operating in 2 phases: "Selection of UTxO" to fulfill a transaction requirement, and "Improve" to do some cleanup of "dust" UTxO present in the wallet UTxO set.
As every included UTxO raise the transaction size, leading to an increase in fees, a limit need to be used to prevent the algorithm using necessarily to many UTxOs, either in SELECT phase or in IMPROVE phase.
Now, the SELECT phase is actually random, and have a fallback algorithm that work by sorting the UTxO in an descending order fashion. If the coinselection cannot fulfill a quantity using randomly 20 UTxO, it try again by starting from the bigger one.

### Why the need to remove on limit on the Fallback:
Applying the limit on the fallback 'DESC' selection means that you won't ever be able to reach the real protocol limit, given by max_transaction_size.
Some wallet usage like selling a lot of Native assets at a low price mean that a wallet can hold thousands of dust UTxO without a single large one. In such case, Nami currently don't allow you to send more than 20x(average token sold price) at a time.
The limit should never have been applied to the fallback, but I had many things to think about when I first implemented the Nami coinselection based on Yoroi algorithm specs.