### PR TITLE
Bug: CIP-68 images not displayed correctly

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1749,7 +1749,7 @@ export const getAsset = async (unit) => {
         const metadata = metadataDatum && Data.toJson(metadataDatum.fields[0]);
 
         asset.displayName = metadata.name;
-        asset.image = metadata.image ? linkToSrc(metadata.image) : '';
+        asset.image = metadata.image ? linkToSrc(convertMetadataPropToString(metadata.image)) : '';
         asset.decimals = 0;
       } catch (_e) {
         asset.displayName = asset.name;
@@ -1776,7 +1776,7 @@ export const getAsset = async (unit) => {
         const metadata = metadataDatum && Data.toJson(metadataDatum.fields[0]);
 
         asset.displayName = metadata.name;
-        asset.image = linkToSrc(metadata.logo) || '';
+        asset.image = linkToSrc(convertMetadataPropToString(metadata.logo)) || '';
         asset.decimals = metadata.decimals || 0;
       } catch (_e) {
         asset.displayName = asset.name;
@@ -1803,7 +1803,7 @@ export const getAsset = async (unit) => {
           linkToSrc(convertMetadataPropToString(onchainMetadata.image))) ||
         (result.metadata &&
           result.metadata.logo &&
-          linkToSrc(result.metadata.logo, true)) ||
+          linkToSrc(convertMetadataPropToString(result.metadata.logo), true)) ||
         '';
       asset.decimals = (result.metadata && result.metadata.decimals) || 0;
       if (!asset.name) {


### PR DESCRIPTION
I came across a bug while working with CIP68 tokens, specifically in handling key-value pairs where the value exceeds 64 letters. In such cases, there's a need to split the string into an array of multiple strings. This bug is affecting the correct display of images and the identification of the CIP-68 tokens in Nami wallet.


**Not working in CIP-68**
```json
{
    "name": "...",
    "image": ["ipfs://", "bafkreicoobvutqxnxodrjzyd3h72da67hc2jpuivogsehvzl6zglhnbncq"]
}
```

The fix involves passing the prop into the conversion method before transforming it into a source. 