### PR TITLE
Fix failure to send on Cardano Mainnet.

### DIFF
--- a/src/ui/app/pages/send.jsx
+++ b/src/ui/app/pages/send.jsx
@@ -395,7 +395,13 @@ const Send = () => {
     };
     utxos.current = _utxos;
     _utxos = _utxos.map((utxo) => Buffer.from(utxo.to_bytes()).toString('hex'));
-    const { current_address: milkomedaAddress } = await getMilkomedaData('');
+    let milkomedaAddress = '';
+    try {
+      const { current_address: milkomedaAddressFromReq } = await getMilkomedaData('');
+      milkomedaAddress = milkomedaAddressFromReq
+    } catch (e) {
+      console.log("ERROR: Couldn't get Milkomeda address.")
+    }
     if (!isMounted.current) return;
     setIsLoading(false);
     setTxInfo({ protocolParameters, utxos: _utxos, balance, milkomedaAddress });
@@ -933,6 +939,8 @@ const AddressPopup = ({
         };
       }
     } else if (isM1) {
+      // We allow failure here because we fail to get the user's Milkomeda
+      //   address when they are creating an M1 transaction.
       const { isAllowed, ada, current_address, protocolMagic, assets, ttl } =
         await getMilkomedaData(e.target.value);
 


### PR DESCRIPTION
Users on Twitter have been complaining that when the flint gateway for M1 is not functioning properly it causes them an inability to use the wallet for Cardano mainnet purposes. This obviously shouldn't be the case, so I have added a simple try-catch fix.