### PR TITLE
Fetch UTxO including mempool transactions

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -265,7 +265,7 @@ export const updateTxInfo = async (txHash, pending) => {
       const metadata = getTxMetadata(txHash);
 
       detail.info = await info;
-      if (info) detail.block = await getBlock(detail.info.block_height);
+      if (detail.info) detail.block = await getBlock(detail.info.block_height);
       detail.utxos = await uTxOs;
       detail.metadata = await metadata;
     } else {

--- a/src/ui/app/components/transaction.jsx
+++ b/src/ui/app/components/transaction.jsx
@@ -105,7 +105,7 @@ const Transaction = ({
   };
 
   const getTxDetail = async () => {
-    if (!displayInfo) {
+    if (!displayInfo || (!pending && detail.block === "mempool")) {
       let txDetail = await updateTxInfo(txHash, pending);
       detail.block = txDetail.block;
       onLoad(txHash, txDetail);

--- a/src/ui/app/components/transaction.jsx
+++ b/src/ui/app/components/transaction.jsx
@@ -89,6 +89,7 @@ const Transaction = ({
   addresses,
   network,
   onLoad,
+  pending=false,
 }) => {
   const settings = useStoreState((state) => state.settings.settings);
   const isMounted = useIsMounted();
@@ -98,32 +99,34 @@ const Transaction = ({
 
   const colorMode = {
     iconBg: useColorModeValue('white', 'gray.800'),
-    txBg: useColorModeValue('teal.50', 'gray.700'),
-    txBgHover: useColorModeValue('teal.100', 'gray.600'),
+    txBg: useColorModeValue(pending ? 'gray.100' : 'teal.50', pending ? 'gray.500' : 'gray.700'),
+    txBgHover: useColorModeValue(pending ? 'gray.200' : 'teal.100', pending ? 'gray.400' : 'gray.600'),
     assetsBtnHover: useColorModeValue('teal.200', 'gray.700'),
   };
 
   const getTxDetail = async () => {
     if (!displayInfo) {
-      let txDetail = await updateTxInfo(txHash);
+      let txDetail = await updateTxInfo(txHash, pending);
+      detail.block = txDetail.block;
       onLoad(txHash, txDetail);
       if (!isMounted.current) return;
       setDisplayInfo(genDisplayInfo(txHash, txDetail, currentAddr, addresses));
     }
   };
 
+
   React.useEffect(() => getTxDetail());
   return (
     <AccordionItem borderTop="none" _last={{ borderBottom: 'none' }}>
       <VStack spacing={2}>
-        {displayInfo ? (
+        {displayInfo ?  (
           <Box align="center" fontSize={14} fontWeight={500} color="gray.500">
-            <ReactTimeAgo
+            {pending ? <Text>Pending</Text> : <ReactTimeAgo
               date={displayInfo.date}
               title={displayInfo.formatDate}
               locale="en-US"
               timeStyle="round-minute"
-            />
+            /> }
           </Box>
         ) : (
           <Skeleton width="34%" height="22px" rounded="md" />
@@ -340,7 +343,7 @@ const TxDetail = ({ displayInfo, network }) => {
             >
               {displayInfo.txHash} <ExternalLinkIcon mx="2px" />
             </Link>
-            {displayInfo.detail.metadata.length > 0 ? (
+            {displayInfo.detail.metadata && displayInfo.detail.metadata.length > 0 ? (
               <Button
                 display="inline-block"
                 colorScheme="orange"
@@ -403,7 +406,7 @@ const genDisplayInfo = (txHash, detail, currentAddr, addresses) => {
   }
 
   const type = getTxType(currentAddr, addresses, detail.utxos);
-  const date = dateFromUnix(detail.block.time);
+  const date = detail.block !== "mempool" ? dateFromUnix(detail.block.time) : new Date();
   const amounts = calculateAmount(
     currentAddr,
     detail.utxos,
@@ -489,7 +492,7 @@ const calculateAmount = (currentAddr, uTxOList, validContract = true) => {
   let inputs = compileOutputs(
     uTxOList.inputs.filter(
       (input) =>
-        input.address === currentAddr && !(input.collateral && validContract)
+        input.address === currentAddr && !(input.collateral && validContract) && input.amount
     )
   );
   let outputs = compileOutputs(


### PR DESCRIPTION
This is a first part of a line of contributions based on the Catalyst Proposal [Open Transaction Chaining tooling to speed up Cardano dApps - By MuesliSwap](https://milestones.projectcatalyst.io/projects/1000139).

The PR builds on top of #885 to enable building transaction making usage of knowledge about the current mempool - thus being able to consume UTxOs that are not officially on-chain yet and ignoring such inputs that will be consumed by transactions currently waiting to be confirmed. 