### PR TITLE
[LW-9592] Include legal docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "nami-wallet",
       "version": "3.6.1",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cardano-foundation/ledgerjs-hw-app-cardano": "^6.0.0",
         "@chakra-ui/css-reset": "^2.3.0",

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -56,6 +56,14 @@ export const setStorage = (item) =>
     })
   );
 
+export const removeStorage = (item) =>
+  new Promise((res, rej) =>
+    chrome.storage.local.remove(item, () => {
+      if (chrome.runtime.lastError) rej(chrome.runtime.lastError);
+      res(true);
+    })
+  );
+
 export const encryptWithPassword = async (password, rootKeyBytes) => {
   await Loader.load();
   const rootKeyHex = Buffer.from(rootKeyBytes, 'hex').toString('hex');

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -59,6 +59,7 @@ export const STORAGE = {
   migration: 'migration',
   analyticsConsent: 'analytics',
   userId: 'userId',
+  acceptedLegalDocsVersion: 'acceptedLegalDocsVersion',
 };
 
 export const LOCAL_STORAGE = {

--- a/src/features/analytics/ui/AnalyticsConsentModal.jsx
+++ b/src/features/analytics/ui/AnalyticsConsentModal.jsx
@@ -22,6 +22,7 @@ export const AnalyticsConsentModal = ({ askForConsent, setConsent }) => {
         isOpen={askForConsent}
         isCentered
         onClose={() => setConsent(false)}
+        blockScrollOnMount={false}
       >
         <ModalOverlay />
         <ModalContent>

--- a/src/features/analytics/ui/AnalyticsConsentModal.jsx
+++ b/src/features/analytics/ui/AnalyticsConsentModal.jsx
@@ -10,52 +10,56 @@ import {
 } from '@chakra-ui/modal';
 import { Link, Text } from '@chakra-ui/layout';
 import React from 'react';
+import PrivacyPolicy from '../../../ui/app/components/privacyPolicy';
 
-export const AnalyticsConsentModal = ({
-  askForConsent,
-  setConsent,
-}) => (
-  <Modal size="xs" isOpen={askForConsent} isCentered onClose={() => setConsent(false)}>
-    <ModalOverlay />
-    <ModalContent>
-      <ModalHeader fontSize="md">Legal & analytics</ModalHeader>
-      <ModalCloseButton />
-      <ModalBody>
-        <Text
-          mb="1"
-          fontSize="md"
-          fontWeight="bold"
-          id="terms-of-service-agreement"
-        >
-          Give us a hand to improve your experience
-        </Text>
-        <Text fontSize="sm">
-          By sharing analytics data from your browser, you can help us improve
-          the quality and performance of Nami. For more information on our
-          privacy practices, please see our&nbsp;
-          <Link
-            onClick={() =>
-              window.open('https://www.lace.io/iog-privacy-policy.pdf')
-            }
-            textDecoration="underline"
-          >
-            Privacy Policy
-          </Link>
-          .
-        </Text>
-      </ModalBody>
-      <ModalFooter>
-        <Button
-          mr={3}
-          variant="ghost"
-          onClick={() => setConsent(false)}
-        >
-          decline
-        </Button>
-        <Button colorScheme="teal" onClick={() => setConsent(true)}>
-          Accept
-        </Button>
-      </ModalFooter>
-    </ModalContent>
-  </Modal>
-);
+export const AnalyticsConsentModal = ({ askForConsent, setConsent }) => {
+  const privacyPolRef = React.useRef();
+
+  return (
+    <>
+      <Modal
+        size="xs"
+        isOpen={askForConsent}
+        isCentered
+        onClose={() => setConsent(false)}
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader fontSize="md">Legal & analytics</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Text
+              mb="1"
+              fontSize="md"
+              fontWeight="bold"
+              id="terms-of-service-agreement"
+            >
+              Give us a hand to improve your experience
+            </Text>
+            <Text fontSize="sm">
+              By sharing analytics data from your browser, you can help us
+              improve the quality and performance of Nami. For more information
+              on our privacy practices, please see our&nbsp;
+              <Link
+                onClick={() => privacyPolRef.current.openModal()}
+                textDecoration="underline"
+              >
+                Privacy Policy
+              </Link>
+              .
+            </Text>
+          </ModalBody>
+          <ModalFooter>
+            <Button mr={3} variant="ghost" onClick={() => setConsent(false)}>
+              decline
+            </Button>
+            <Button colorScheme="teal" onClick={() => setConsent(true)}>
+              Accept
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+      <PrivacyPolicy ref={privacyPolRef} />
+    </>
+  );
+};

--- a/src/features/analytics/ui/AnalyticsConsentModal.jsx
+++ b/src/features/analytics/ui/AnalyticsConsentModal.jsx
@@ -51,7 +51,7 @@ export const AnalyticsConsentModal = ({ askForConsent, setConsent }) => {
           </ModalBody>
           <ModalFooter>
             <Button mr={3} variant="ghost" onClick={() => setConsent(false)}>
-              decline
+              Decline
             </Button>
             <Button colorScheme="teal" onClick={() => setConsent(true)}>
               Accept

--- a/src/features/terms-and-privacy/config.ts
+++ b/src/features/terms-and-privacy/config.ts
@@ -1,0 +1,1 @@
+export const CURRENT_VERSION = 1;

--- a/src/features/terms-and-privacy/hooks.ts
+++ b/src/features/terms-and-privacy/hooks.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getAcceptedLegalDocsVersion,
+  setAcceptedLegalDocsVersion,
+} from './services';
+import { CURRENT_VERSION } from './config';
+
+export const useAcceptDocs = () => {
+  const [accept, setAccept] = useState(false);
+
+  return {
+    accept,
+    setAccept: useCallback(
+      (accepted: boolean) => {
+        setAccept(accepted);
+        setAcceptedLegalDocsVersion(accepted ? CURRENT_VERSION : undefined);
+      },
+      [setAccept]
+    ),
+  };
+};
+
+export const useShowUpdatePrompt = () => {
+  const [showUpdatePrompt, setShowUpdatePrompt] = useState<boolean | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    const init = async () => {
+      const acceptedVersion = await getAcceptedLegalDocsVersion();
+
+      if (acceptedVersion) {
+        setShowUpdatePrompt(acceptedVersion < CURRENT_VERSION);
+      } else {
+        setShowUpdatePrompt(true);
+      }
+    };
+
+    init();
+  }, []);
+
+  return {
+    showUpdatePrompt,
+    hideUpdatePrompt: useCallback(() => {
+      setShowUpdatePrompt(false);
+    }, [setShowUpdatePrompt]),
+  };
+};

--- a/src/features/terms-and-privacy/hooks.ts
+++ b/src/features/terms-and-privacy/hooks.ts
@@ -21,7 +21,7 @@ export const useAcceptDocs = () => {
 };
 
 export const useShowUpdatePrompt = () => {
-  const [showUpdatePrompt, setShowUpdatePrompt] = useState<boolean | undefined>(
+  const [shouldShowUpdatePrompt, setShouldShowUpdatePrompt] = useState<boolean | undefined>(
     undefined
   );
 
@@ -30,9 +30,9 @@ export const useShowUpdatePrompt = () => {
       const acceptedVersion = await getAcceptedLegalDocsVersion();
 
       if (acceptedVersion) {
-        setShowUpdatePrompt(acceptedVersion < CURRENT_VERSION);
+        setShouldShowUpdatePrompt(acceptedVersion < CURRENT_VERSION);
       } else {
-        setShowUpdatePrompt(true);
+        setShouldShowUpdatePrompt(true);
       }
     };
 
@@ -40,9 +40,9 @@ export const useShowUpdatePrompt = () => {
   }, []);
 
   return {
-    showUpdatePrompt,
+    shouldShowUpdatePrompt,
     hideUpdatePrompt: useCallback(() => {
-      setShowUpdatePrompt(false);
-    }, [setShowUpdatePrompt]),
+      setShouldShowUpdatePrompt(false);
+    }, [setShouldShowUpdatePrompt]),
   };
 };

--- a/src/features/terms-and-privacy/hooks.ts
+++ b/src/features/terms-and-privacy/hooks.ts
@@ -6,16 +6,16 @@ import {
 import { CURRENT_VERSION } from './config';
 
 export const useAcceptDocs = () => {
-  const [accept, setAccept] = useState(false);
+  const [accepted, setAccepted] = useState(false);
 
   return {
-    accept,
-    setAccept: useCallback(
+    accepted,
+    setAccepted: useCallback(
       (accepted: boolean) => {
-        setAccept(accepted);
+        setAccepted(accepted);
         setAcceptedLegalDocsVersion(accepted ? CURRENT_VERSION : undefined);
       },
-      [setAccept]
+      [setAccepted]
     ),
   };
 };

--- a/src/features/terms-and-privacy/index.ts
+++ b/src/features/terms-and-privacy/index.ts
@@ -1,0 +1,1 @@
+export { TermsAndPrivacyProvider } from './provider';

--- a/src/features/terms-and-privacy/provider.tsx
+++ b/src/features/terms-and-privacy/provider.tsx
@@ -1,0 +1,21 @@
+import React, { ReactNode } from 'react';
+import { TermsAndPrivacyModal } from './ui/TermsAndPrivacyModal';
+import { useShowUpdatePrompt } from './hooks';
+
+interface Props {
+  children: ReactNode;
+}
+
+export const TermsAndPrivacyProvider = ({ children }: Props) => {
+  const { showUpdatePrompt, hideUpdatePrompt } = useShowUpdatePrompt();
+
+  if (showUpdatePrompt === undefined) {
+    return;
+  }
+
+  return showUpdatePrompt ? (
+    <TermsAndPrivacyModal onContinue={hideUpdatePrompt} />
+  ) : (
+    children
+  );
+};

--- a/src/features/terms-and-privacy/provider.tsx
+++ b/src/features/terms-and-privacy/provider.tsx
@@ -7,13 +7,13 @@ interface Props {
 }
 
 export const TermsAndPrivacyProvider = ({ children }: Props) => {
-  const { showUpdatePrompt, hideUpdatePrompt } = useShowUpdatePrompt();
+  const { shouldShowUpdatePrompt, hideUpdatePrompt } = useShowUpdatePrompt();
 
-  if (showUpdatePrompt === undefined) {
+  if (shouldShowUpdatePrompt === undefined) {
     return;
   }
 
-  return showUpdatePrompt ? (
+  return shouldShowUpdatePrompt ? (
     <TermsAndPrivacyModal onContinue={hideUpdatePrompt} />
   ) : (
     children

--- a/src/features/terms-and-privacy/services.ts
+++ b/src/features/terms-and-privacy/services.ts
@@ -6,19 +6,13 @@ export const getAcceptedLegalDocsVersion = async (): Promise<
 > => {
   const version = await getStorage(STORAGE.acceptedLegalDocsVersion);
 
-  if (version) {
-    return Number(version);
-  }
-
-  return undefined;
+  return version ? Number(version) : undefined;
 };
 
 export const setAcceptedLegalDocsVersion = (
   version: number | undefined
 ): Promise<boolean> => {
-  if (version) {
-    return setStorage({ [STORAGE.acceptedLegalDocsVersion]: version });
-  }
-
-  return removeStorage(STORAGE.acceptedLegalDocsVersion);
+  return version
+    ? setStorage({ [STORAGE.acceptedLegalDocsVersion]: version })
+    : removeStorage(STORAGE.acceptedLegalDocsVersion);
 };

--- a/src/features/terms-and-privacy/services.ts
+++ b/src/features/terms-and-privacy/services.ts
@@ -1,0 +1,24 @@
+import { getStorage, removeStorage, setStorage } from '../../api/extension';
+import { STORAGE } from '../../config/config';
+
+export const getAcceptedLegalDocsVersion = async (): Promise<
+  number | undefined
+> => {
+  const version = await getStorage(STORAGE.acceptedLegalDocsVersion);
+
+  if (version) {
+    return Number(version);
+  }
+
+  return undefined;
+};
+
+export const setAcceptedLegalDocsVersion = (
+  version: number | undefined
+): Promise<boolean> => {
+  if (version) {
+    return setStorage({ [STORAGE.acceptedLegalDocsVersion]: version });
+  }
+
+  return removeStorage(STORAGE.acceptedLegalDocsVersion);
+};

--- a/src/features/terms-and-privacy/ui/TermsAndPrivacyModal.jsx
+++ b/src/features/terms-and-privacy/ui/TermsAndPrivacyModal.jsx
@@ -17,7 +17,7 @@ import { useAcceptDocs } from '../hooks';
 export const TermsAndPrivacyModal = ({ onContinue }) => {
   const termsRef = React.useRef();
   const privacyPolicyRef = React.useRef();
-  const { accept, setAccept } = useAcceptDocs();
+  const { accepted, setAccepted } = useAcceptDocs();
 
   return (
     <>
@@ -33,7 +33,7 @@ export const TermsAndPrivacyModal = ({ onContinue }) => {
                 The terms of use and privacy policy have been updated.
               </Text>
               <Box display="flex" mb="2">
-                <Checkbox onChange={(e) => setAccept(e.target.checked)} />
+                <Checkbox onChange={(e) => setAccepted(e.target.checked)} />
                 <Box display="inline" ml="2">
                   <Text fontWeight={600}>
                     I read and accepted the{' '}
@@ -57,7 +57,7 @@ export const TermsAndPrivacyModal = ({ onContinue }) => {
           </ModalBody>
           <ModalFooter>
             <Button
-              isDisabled={!accept}
+              isDisabled={!accepted}
               colorScheme="teal"
               onClick={onContinue}
             >

--- a/src/features/terms-and-privacy/ui/TermsAndPrivacyModal.jsx
+++ b/src/features/terms-and-privacy/ui/TermsAndPrivacyModal.jsx
@@ -1,0 +1,73 @@
+import { Button } from '@chakra-ui/button';
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/modal';
+import { Checkbox } from '@chakra-ui/checkbox';
+import { Link, Text, Box } from '@chakra-ui/layout';
+import React from 'react';
+import PrivacyPolicy from '../../../ui/app/components/privacyPolicy';
+import TermsOfUse from '../../../ui/app/components/termsOfUse';
+import { useAcceptDocs } from '../hooks';
+
+export const TermsAndPrivacyModal = ({ onContinue }) => {
+  const termsRef = React.useRef();
+  const privacyPolicyRef = React.useRef();
+  const { accept, setAccept } = useAcceptDocs();
+
+  return (
+    <>
+      <Modal size="xs" isOpen isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader fontSize="md">
+            Terms of use and Privacy Policy
+          </ModalHeader>
+          <ModalBody>
+            <Box display="flex" flexDirection="column">
+              <Text mb="2">
+                The terms of use and privacy policy have been updated.
+              </Text>
+              <Box display="flex" mb="2">
+                <Checkbox onChange={(e) => setAccept(e.target.checked)} />
+                <Box display="inline" ml="2">
+                  <Text fontWeight={600}>
+                    I read and accepted the{' '}
+                    <Link
+                      onClick={() => termsRef.current.openModal()}
+                      textDecoration="underline"
+                    >
+                      Terms of use
+                    </Link>
+                    <Text display="inline"> and </Text>
+                    <Link
+                      onClick={() => privacyPolicyRef.current.openModal()}
+                      textDecoration="underline"
+                    >
+                      Privacy Policy
+                    </Link>
+                  </Text>
+                </Box>
+              </Box>
+            </Box>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              isDisabled={!accept}
+              colorScheme="teal"
+              onClick={onContinue}
+            >
+              Continue
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+      <PrivacyPolicy ref={privacyPolicyRef} />
+      <TermsOfUse ref={termsRef} />
+    </>
+  );
+};

--- a/src/features/terms-and-privacy/ui/TermsAndPrivacyModal.tsx
+++ b/src/features/terms-and-privacy/ui/TermsAndPrivacyModal.tsx
@@ -25,7 +25,13 @@ export const TermsAndPrivacyModal = ({ onContinue }: Props) => {
 
   return (
     <>
-      <Modal size="xs" isOpen isCentered onClose={() => void 0}>
+      <Modal
+        size="xs"
+        isOpen
+        isCentered
+        onClose={() => void 0}
+        blockScrollOnMount={false}
+      >
         <ModalOverlay />
         <ModalContent>
           <ModalHeader fontSize="md">

--- a/src/features/terms-and-privacy/ui/TermsAndPrivacyModal.tsx
+++ b/src/features/terms-and-privacy/ui/TermsAndPrivacyModal.tsx
@@ -9,19 +9,23 @@ import {
 } from '@chakra-ui/modal';
 import { Checkbox } from '@chakra-ui/checkbox';
 import { Link, Text, Box } from '@chakra-ui/layout';
-import React from 'react';
+import React, { useRef } from 'react';
 import PrivacyPolicy from '../../../ui/app/components/privacyPolicy';
 import TermsOfUse from '../../../ui/app/components/termsOfUse';
 import { useAcceptDocs } from '../hooks';
 
-export const TermsAndPrivacyModal = ({ onContinue }) => {
-  const termsRef = React.useRef();
-  const privacyPolicyRef = React.useRef();
+interface Props {
+  onContinue: () => void;
+}
+
+export const TermsAndPrivacyModal = ({ onContinue }: Props) => {
+  const termsRef = useRef<{ openModal: () => void }>();
+  const privacyPolicyRef = useRef<{ openModal: () => void }>();
   const { accepted, setAccepted } = useAcceptDocs();
 
   return (
     <>
-      <Modal size="xs" isOpen isCentered>
+      <Modal size="xs" isOpen isCentered onClose={() => void 0}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader fontSize="md">
@@ -38,14 +42,14 @@ export const TermsAndPrivacyModal = ({ onContinue }) => {
                   <Text fontWeight={600}>
                     I read and accepted the{' '}
                     <Link
-                      onClick={() => termsRef.current.openModal()}
+                      onClick={() => termsRef.current?.openModal()}
                       textDecoration="underline"
                     >
                       Terms of use
                     </Link>
                     <Text display="inline"> and </Text>
                     <Link
-                      onClick={() => privacyPolicyRef.current.openModal()}
+                      onClick={() => privacyPolicyRef.current?.openModal()}
                       textDecoration="underline"
                     >
                       Privacy Policy

--- a/src/ui/app/components/about.jsx
+++ b/src/ui/app/components/about.jsx
@@ -44,7 +44,13 @@ const About = React.forwardRef((props, ref) => {
   }));
   return (
     <>
-      <Modal size="xs" isOpen={isOpen} onClose={onClose} isCentered>
+      <Modal
+        size="xs"
+        isOpen={isOpen}
+        onClose={onClose}
+        isCentered
+        blockScrollOnMount={false}
+      >
         <ModalOverlay />
         <ModalContent>
           <ModalHeader fontSize="md">About</ModalHeader>

--- a/src/ui/app/components/privacyPolicy.jsx
+++ b/src/ui/app/components/privacyPolicy.jsx
@@ -588,7 +588,7 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
                 IOG may update this Privacy Policy from time to time. Such
                 changes will be posted on this page. The effective date of such
                 changes will be notified via email and/or a prominent notice on
-                the Product, with an update the "effective date" at the top of
+                the Product, with an update to the "effective date" at the top of
                 this Privacy Policy.
               </Text>
               <Text mb="3">

--- a/src/ui/app/components/privacyPolicy.jsx
+++ b/src/ui/app/components/privacyPolicy.jsx
@@ -9,6 +9,9 @@ import {
   ModalHeader,
   ModalOverlay,
   useDisclosure,
+  UnorderedList,
+  ListItem,
+  Link,
 } from '@chakra-ui/react';
 import { Scrollbars } from './scrollbar';
 
@@ -32,93 +35,606 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
         <ModalBody pr="0.5">
           <Scrollbars style={{ width: '100%', height: '400px' }}>
             <Box width="92%">
-              <Text
-                mb="1"
-                fontSize="md"
-                fontWeight="bold"
-                id="terms-of-service-agreement"
-              >
-                Privacy Policy
+              <Text mb="3">Last updated September 6, 2023</Text>
+
+              <Text mb="3">
+                Thank you for choosing to be part of our community at Input
+                Output Global, Inc., (together with our subsidiaries and
+                affiliates, "IOG", "we", "us", or "our"). This Privacy Policy
+                applies to all personal information collected through this
+                website and all of IOG's related websites, mobile apps,
+                products, services, sales, marketing or events, including our
+                plug-ins and browser extensions (collectively, the{' '}
+                <Text display="inline" fontWeight="bold">
+                  "Products"
+                </Text>
+                ).
               </Text>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-                eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                Praesent semper feugiat nibh sed. Odio euismod lacinia at quis
-                risus. Id volutpat lacus laoreet non curabitur gravida arcu ac
-                tortor. Pretium viverra suspendisse potenti nullam ac tortor
-                vitae. Massa sapien faucibus et molestie ac feugiat sed lectus
-                vestibulum. Diam quis enim lobortis scelerisque fermentum dui
-                faucibus in ornare. At auctor urna nunc id cursus metus aliquam.
-                Quam nulla porttitor massa id neque. Arcu odio ut sem nulla
-                pharetra diam sit amet. Erat imperdiet sed euismod nisi porta.
-              </p>
 
-              <p>
-                Amet consectetur adipiscing elit duis tristique sollicitudin
-                nibh sit. Porttitor lacus luctus accumsan tortor. Mauris nunc
-                congue nisi vitae. In vitae turpis massa sed elementum tempus.
-                Ut porttitor leo a diam sollicitudin tempor id. Condimentum
-                vitae sapien pellentesque habitant. Est velit egestas dui id
-                ornare arcu. Egestas maecenas pharetra convallis posuere morbi
-                leo. Nisl condimentum id venenatis a condimentum vitae sapien
-                pellentesque habitant. Cursus vitae congue mauris rhoncus
-                aenean. Lacus suspendisse faucibus interdum posuere lorem ipsum
-                dolor sit amet. Sodales neque sodales ut etiam sit amet nisl.
-                Morbi quis commodo odio aenean sed. Pharetra vel turpis nunc
-                eget. Sed adipiscing diam donec adipiscing tristique risus nec
-                feugiat in.
-              </p>
+              <Text mb="3">
+                We are committed to protecting your personal information. When
+                you access or use our Products, you trust us with your personal
+                information. In this Privacy Policy, we describe how we collect,
+                use, store and share your personal information and what rights
+                you have in relation to it. If there are any terms in this
+                Privacy Policy that you do not agree with, please discontinue
+                access and use of our Products.
+              </Text>
 
-              <p>
-                Eget nunc lobortis mattis aliquam faucibus purus in massa. Nunc
-                faucibus a pellentesque sit amet porttitor eget. Maecenas
-                ultricies mi eget mauris pharetra. Rhoncus urna neque viverra
-                justo nec ultrices dui sapien eget. Id volutpat lacus laoreet
-                non. Volutpat sed cras ornare arcu dui vivamus arcu. Facilisis
-                volutpat est velit egestas dui id. Ultricies mi quis hendrerit
-                dolor. Odio morbi quis commodo odio aenean sed adipiscing diam
-                donec. Urna molestie at elementum eu facilisis. Tincidunt nunc
-                pulvinar sapien et ligula ullamcorper malesuada proin. Vitae
-                elementum curabitur vitae nunc. Eget mauris pharetra et ultrices
-                neque ornare. Nulla facilisi etiam dignissim diam. Amet risus
-                nullam eget felis eget nunc lobortis. Vivamus arcu felis
-                bibendum ut tristique et egestas. Vitae justo eget magna
-                fermentum iaculis eu non.
-              </p>
+              <Text mb="4">
+                Please read this Privacy Policy carefully as it will help you
+                make informed decisions about sharing your personal information
+                with us.
+              </Text>
 
-              <p>
-                Massa placerat duis ultricies lacus sed. Ultricies lacus sed
-                turpis tincidunt id aliquet risus feugiat in. Erat imperdiet sed
-                euismod nisi porta lorem mollis aliquam. Dictum non consectetur
-                a erat nam at lectus urna duis. Quam pellentesque nec nam
-                aliquam sem et. Eros donec ac odio tempor. Sem viverra aliquet
-                eget sit amet. Semper risus in hendrerit gravida rutrum quisque
-                non. Cras fermentum odio eu feugiat pretium nibh ipsum
-                consequat. Elit scelerisque mauris pellentesque pulvinar
-                pellentesque habitant. Nulla facilisi etiam dignissim diam quis
-                enim lobortis. Sed nisi lacus sed viverra tellus in. Dictumst
-                vestibulum rhoncus est pellentesque elit ullamcorper dignissim
-                cras tincidunt. Dolor morbi non arcu risus quis varius quam
-                quisque id. Integer enim neque volutpat ac tincidunt.
-                Ullamcorper malesuada proin libero nunc. Varius vel pharetra vel
-                turpis nunc eget lorem dolor sed. Ullamcorper velit sed
-                ullamcorper morbi tincidunt ornare massa eget egestas.
-              </p>
+              <Text mb="3" fontWeight="bold">
+                1. Collection of Data
+              </Text>
+              <Text mb="4">
+                IOG collects several types of information for various purposes
+                to provide and improve the Products for your use.
+              </Text>
 
-              <p>
-                Porta nibh venenatis cras sed felis eget velit aliquet sagittis.
-                Augue ut lectus arcu bibendum at. Amet luctus venenatis lectus
-                magna. Pharetra vel turpis nunc eget. Ligula ullamcorper
-                malesuada proin libero nunc. Ullamcorper malesuada proin libero
-                nunc consequat interdum. Ac placerat vestibulum lectus mauris.
-                Facilisis sed odio morbi quis commodo odio aenean. Scelerisque
-                eu ultrices vitae auctor eu augue ut lectus arcu. Consectetur
-                adipiscing elit ut aliquam purus. Risus sed vulputate odio ut
-                enim blandit volutpat maecenas. Mauris cursus mattis molestie a
-                iaculis at erat pellentesque adipiscing. Id venenatis a
-                condimentum vitae sapien. Dapibus ultrices in iaculis nunc sed
-                augue lacus viverra.
-              </p>
+              <Text mb="4" fontWeight="bold">
+                Types of Data Collected
+              </Text>
+              <UnorderedList>
+                <ListItem>
+                  <Text fontWeight="bold">Personal Data</Text>
+                  <Text mb="4">
+                    While using the Products, IOG may ask you to provide certain
+                    personally identifiable information that can be used to
+                    contact or identify you (
+                    <Text display="inline" fontWeight="bold">
+                      "Personal Data"
+                    </Text>
+                    ), which may include, but is not limited to:
+                  </Text>
+                  <UnorderedList mb="4" styleType="circle">
+                    <ListItem>Email address</ListItem>
+                    <ListItem>First name and last name</ListItem>
+                    <ListItem>Phone number</ListItem>
+                    <ListItem>
+                      Address, State, Province, ZIP/Postal code, City
+                    </ListItem>
+                    <ListItem>Cookies and Usage Data</ListItem>
+                  </UnorderedList>
+                  <Text mb="4">
+                    Your Personal Data may be used to contact you with
+                    newsletters, marketing or promotional materials and other
+                    information that may be of interest to you. You may opt out
+                    of receiving any, or all, of these communications by
+                    following the unsubscribe link or instructions provided in
+                    any email sent to you by IOG.
+                  </Text>
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold">Usage Information</Text>
+                  <Text mb="4">
+                    Usage Information refers to information collected from
+                    Products such as what action has been applied to Products
+                    such as clicking logs; your registration details or how you
+                    may be using Products.
+                  </Text>
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold">IP Address</Text>
+                  <Text mb="4">
+                    When you use Products, we may automatically log your IP
+                    address (the unique address which identifies your computer
+                    on the internet) which is automatically recognized by our
+                    server.
+                  </Text>
+                </ListItem>
+              </UnorderedList>
+
+              <Text mb="3" fontWeight="bold">
+                2. Use of Data
+              </Text>
+              <Text mb="2">
+                Specifically, IOG uses your information for the purpose for
+                which you provided it to us such as:
+              </Text>
+              <UnorderedList mb="4">
+                <ListItem>To notify you about changes to Products</ListItem>
+                <ListItem>
+                  To allow you to participate in interactive features of
+                  Products when you choose to do so
+                </ListItem>
+                <ListItem>To provide customer support</ListItem>
+                <ListItem>
+                  To gather analysis or valuable information so that we can
+                  improve the website
+                </ListItem>
+                <ListItem>To monitor the usage of Products</ListItem>
+                <ListItem>
+                  To detect, prevent and address technical issues
+                </ListItem>
+                <ListItem>
+                  To provide you with news, special offers and general
+                  information about other goods, services and events which IOG
+                  offers that are similar to those that you have already
+                  purchased or enquired about unless you have opted not to
+                  receive such information
+                </ListItem>
+              </UnorderedList>
+              <Text mb="4">
+                Where and as permitted under applicable law, IOG may process
+                your contact information for direct marketing purposes (e.g.,
+                event invitations, newsletters) and to carry out customer
+                satisfaction surveys, in each case also by email. You may object
+                to the processing of your contact data for these purposes at any
+                time by writing to{' '}
+                <Link href="mailto:legal@iohk.io">legal@iohk.io</Link> or by
+                using the opt-out mechanism provided in the respective
+                communication you received.
+              </Text>
+
+              <Text mb="4" fontWeight="bold">
+                3. Legal Basis under General Data Protection Regulation (GDPR)
+              </Text>
+              <Text mb="3">
+                For a citizen or resident of a member country of the European
+                Union (EU) or the European Economic Area (EEA), the legal basis
+                for collecting and using Personal Data described in this Privacy
+                Policy depends on the Personal Data being collected and the
+                specific context in which it is collected as described below:
+              </Text>
+              <Text mb="2">IOG may process your Personal Data because:</Text>
+              <UnorderedList mb="3">
+                <ListItem>IOG needs to perform a contract with you</ListItem>
+                <ListItem>You have given us permission to do so</ListItem>
+                <ListItem>
+                  The processing derives from IOG's legitimate interests
+                </ListItem>
+                <ListItem>IOG has to comply with applicable law</ListItem>
+              </UnorderedList>
+              <Text mb="3">
+                The legal basis for IOG processing data about you is that it is
+                necessary for the purposes of:
+              </Text>
+              <UnorderedList mb="3">
+                <ListItem>
+                  IOG exercising its rights and performing its obligations in
+                  connection with any contract make with you (Article 6 (1) (b)
+                  General Data Protection Regulation),
+                </ListItem>
+                <ListItem>
+                  Compliance with IOG's legal obligations (Article 6 (1) (c)
+                  General Data Protection Regulation), and/or
+                </ListItem>
+                <ListItem>
+                  Legitimate interests pursued by IOG (Article 6 (1) (f) General
+                  Data Protection Regulation).
+                </ListItem>
+              </UnorderedList>
+              <Text mb="3">
+                Generally the legitimate interest pursued by IOG in relation to
+                our use of your personal data is the efficient performance or
+                management of our business relationship with you.
+              </Text>
+              <Text mb="4">
+                In some cases, we may ask if you consent to the relevant use of
+                your personal data. In such cases, the legal basis for IOG
+                processing that data about you may (in addition or instead) be
+                that you have consented (Article 6 (1) (a) General Data
+                Protection Regulation).
+              </Text>
+
+              <Text mb="3" fontWeight="bold">
+                4. Retention of Data
+              </Text>
+              <Text mb="3">
+                IOG will retain your Personal Data only for as long as is
+                necessary for the purposes set out in this Privacy Policy. IOG
+                will retain and use your Personal Data to the extent necessary
+                to comply with our legal obligations (for example, if IOG is
+                required to retain your Personal Data to comply with applicable
+                laws), resolve disputes, and enforce legal agreements and
+                policies.
+              </Text>
+              <Text mb="4">
+                IOG will also retain Usage Data for internal analysis purposes.
+                Usage Data is generally retained for a shorter period of time,
+                except when this data is used to strengthen the security or to
+                improve the functionality of Products, or IOG is legally
+                obligated to retain such data for longer time periods.
+              </Text>
+
+              <Text mb="3" fontWeight="bold">
+                5. Transfer Of Data
+              </Text>
+              <Text mb="3">
+                Your information, including Personal Data, may be transferred to
+                — and maintained on — computers located outside of your state,
+                province, country or other governmental jurisdiction where the
+                data protection laws may differ from those from your
+                jurisdiction.
+              </Text>
+              <Text mb="3">
+                Your use of Products under the IOG Terms of Use followed by your
+                submission of your personal information constitutes your
+                unreserved agreement to this Privacy Policy in general and the
+                transfer of data under this policy in particular.
+              </Text>
+              <Text mb="4">
+                IOG will take all steps reasonably necessary to ensure that your
+                data is treated securely and in accordance with this Privacy
+                Policy and no transfer of your Personal Data will take place to
+                an organization or a country unless there are adequate controls
+                in place including the security of your data and other personal
+                information.
+              </Text>
+
+              <Text mb="3" fontWeight="bold">
+                6. Disclosure Of Data
+              </Text>
+              <Text mb="3" fontWeight="bold">
+                Legal Requirements
+              </Text>
+              <Text mb="2">
+                IOG may disclose your Personal Data in good faith belief that
+                such disclosure is necessary to:
+              </Text>
+              <UnorderedList mb="3">
+                <ListItem>To comply with a legal obligation</ListItem>
+                <ListItem>
+                  To protect and defend the rights or property of IOG
+                </ListItem>
+                <ListItem>
+                  To prevent or investigate possible wrongdoing in connection
+                  with Products
+                </ListItem>
+                <ListItem>
+                  To protect the personal safety of users of Products or the
+                  public
+                </ListItem>
+                <ListItem>To protect against legal liability</ListItem>
+              </UnorderedList>
+              <Text fontWeight="bold">
+                Disclosure of Personal Information Within The EU
+              </Text>
+              <Text mb="3">
+                Insofar as we employ the services of service providers to
+                implement or fulfill any tasks on our behalf, the contractual
+                relations will be regulated in writing according to the
+                provisions of the European General Data Protection Regulation
+                (EU-GDPR) and the Federal Data Protection Act (new BDSG).
+              </Text>
+              <Text fontWeight="bold">
+                Disclosure of Personal Information Outside of The EU
+              </Text>
+              <Text mb="3">
+                Insofar as you have selected and consented to this in the form,
+                your data will be disclosed to our offices within the network of
+                affiliated companies outside of the European economic area for
+                the processing of your enquiry. These offices are legally
+                obligated to abide by the EU-GDPR. Furthermore, between the
+                legally autonomous companies in the network of affiliated
+                companies, written agreements exist for the processing of data
+                on commission, based on standardized contract stipulations.
+              </Text>
+              <Text mb="4" fontWeight="bold">
+                7. Security Of Data
+              </Text>
+              <Text mb="3">
+                We use reasonable technical and organizational methods to
+                safeguard your information, for example, by password protecting
+                (via usernames and passwords unique to you) certain parts of the
+                Products and by using SSL encryption and firewalls to protect
+                against unauthorized access, disclosure, alteration or
+                destruction. However, please note that this is not a guarantee
+                that such information may not be accessed, disclosed, altered or
+                destroyed by breach of such firewalls and secure server
+                software.
+              </Text>
+              <Text mb="3">
+                Whilst we will use all reasonable efforts to safeguard your
+                information, you acknowledge that data transmissions over the
+                internet cannot be guaranteed to be 100% secure and for this
+                reason we cannot guarantee the security or integrity of any
+                Personal Information that is transferred from you or to you via
+                the internet and as such, any information you transfer to IOG is
+                done at your own risk.
+              </Text>
+              <Text mb="3">
+                Where we have given you (or where you have chosen) a password
+                which enables you to access certain parts of our site, you are
+                responsible for keeping this password confidential. We ask you
+                not to share a password with anyone.
+              </Text>
+              <Text mb="4">
+                If we learn of a security systems breach we may attempt to
+                notify you electronically so that you can take appropriate
+                protective steps. By using Products or providing Personal
+                Information to us you agree that we can communicate with you
+                electronically regarding security, privacy and administrative
+                issues relating to your use of Products. We may post a notice on
+                Products if a security breach occurs. We may also send an email
+                to you at the email address you have provided to us in these
+                circumstances. Depending on where you live, you may have a legal
+                right to receive notice of a security breach in writing.
+              </Text>
+
+              <Text mb="4" fontWeight="bold">
+                8. Rights Under General Data Protection Regulation (GDPR)
+              </Text>
+              <Text mb="3">
+                If you are a citizen or resident of a member country of the
+                European Union (EU) or the European Economic Area (EEA), you
+                have certain data protection rights. IOG aims to take reasonable
+                steps to allow you to correct, amend, delete, or limit the use
+                of your Personal Data.
+              </Text>
+
+              <Text mb="3">
+                If you wish to be informed what Personal Data IOG holds about
+                you and if you want it to be removed from our systems, please
+                contact us{' '}
+                <Link href="mailto:legal@iohk.io">legal@iohk.io</Link>.
+              </Text>
+              <Text mb="2">
+                In certain circumstances, you have the following data protection
+                rights:
+              </Text>
+              <UnorderedList mb="3">
+                <ListItem>
+                  <Text display="inline" fontWeight="bold">
+                    The right to access.
+                  </Text>{' '}
+                  You have the right to request information concerning the
+                  personal information we hold that relates to you.
+                </ListItem>
+                <ListItem>
+                  <Text display="inline" fontWeight="bold">
+                    The right of rectification.
+                  </Text>{' '}
+                  You have the right to have your information rectified if that
+                  information is inaccurate or incomplete.
+                </ListItem>
+                <ListItem>
+                  <Text display="inline" fontWeight="bold">
+                    The right to object.
+                  </Text>{' '}
+                  You have the right to object to your personal information
+                  being used for a particular purpose, and you can exercise
+                  these rights, for example, via an unsubscribe link at the
+                  bottom of any email.
+                </ListItem>
+                <ListItem>
+                  <Text display="inline" fontWeight="bold">
+                    The right of restriction.
+                  </Text>{' '}
+                  You have the right to request that IOG restricts the
+                  processing of your personal information.
+                </ListItem>
+                <ListItem>
+                  <Text display="inline" fontWeight="bold">
+                    The right to data portability.
+                  </Text>{' '}
+                  You have the right to be provided with a copy of the
+                  information IOG has on you in a structured, machine-readable,
+                  and commonly used format.
+                </ListItem>
+                <ListItem>
+                  <Text display="inline" fontWeight="bold">
+                    The right to withdraw consent.
+                  </Text>{' '}
+                  You also have the right to withdraw your consent at any time
+                  where IOG relied on your consent to process your personal
+                  information.
+                </ListItem>
+              </UnorderedList>
+              <Text mb="3">
+                Please note that IOG may ask you to verify your identity before
+                responding to such requests.
+              </Text>
+              <Text mb="4">
+                You have the right to complain to a Data Protection Authority
+                about our collection and use of your Personal Data. For more
+                information, please contact your local data protection authority
+                in the EU or EEA.
+              </Text>
+
+              <Text mb="4" fontWeight="bold">
+                9. California Residents
+              </Text>
+              <Text mb="3" fontWeight="bold">
+                If you are a California resident, you have certain rights with
+                respect to your personal information pursuant to the California
+                Consumer Privacy Act of 2018 (“CCPA”). This section applies to
+                you.
+              </Text>
+              <Text mb="3" fontWeight="bold">
+                We are required to inform you of: (i) what categories of
+                information we collect about you, including during the preceding
+                12 months, (ii) the purposes for which we use your personal
+                data, including during the preceding 12 months, and (iii) the
+                purposes for which we share your personal data, including during
+                the preceding 12 months.
+              </Text>
+              <Text mb="3">
+                You have the right to: (i) request a copy of the personal
+                information that we have about you; (ii) request that we delete
+                your personal information; and (iii) opt-out of the sale of your
+                personal information. You can limit the use of tracking
+                technologies, such as cookies, by following instructions in the
+                “Your choices” section. These rights are subject to limitations
+                as described in the CCPA.
+              </Text>
+              <Text mb="3">
+                We will not discriminate against any consumer for exercising
+                their CCPA rights.
+              </Text>
+              <Text mb="4">
+                If you would like to exercise any of these rights, please
+                contact us at{' '}
+                <Link href="mailto:legal@iohk.io">legal@iohk.io</Link>.
+              </Text>
+
+              <Text mb="4" fontWeight="bold">
+                10. Service Providers, Plugins, and Tools
+              </Text>
+              <Text mb="3">
+                IOG may employ third-party companies and individuals to
+                facilitate Products, to provide the Products on our behalf, to
+                perform website-related services, or to assist us in analyzing
+                how the Products are used (
+                <Text display="inline" fontWeight="bold">
+                  "Service Providers"
+                </Text>
+                ).
+              </Text>
+              <Text mb="3">
+                These Service Providers have access to your Personal Data only
+                to perform these tasks on our behalf and are obligated not to
+                disclose or use it for any other purpose.
+              </Text>
+              <Text fontWeight="bold">Social Media</Text>
+              <Text mb="3">
+                IOG may use social media plugins to enable a better user
+                experience with the use of Products.
+              </Text>
+
+              <Text fontWeight="bold">Youtube</Text>
+              <Text mb="3">
+                IOG uses the YouTube video platform operated by YouTube LLC, 901
+                Cherry Ave. San Bruno, CA 94066 USA. YouTube is a platform that
+                enables playback of audio and video files. If you visit one of
+                our pages featuring a YouTube plugin, a connection to the
+                YouTube servers is established. Here the YouTube server is
+                informed about which of our pages you have visited. If you’re
+                logged in to your YouTube account, YouTube allows you to
+                associate your browsing behavior directly with your personal
+                profile. You can prevent this by logging out of your YouTube
+                account. YouTube is used to help make our website appealing. For
+                information about the scope and purpose of data collection, the
+                further processing and use of the data by YouTube, and your
+                rights and the settings you can configure to protect your
+                privacy, please refer to the YouTube Privacy Guidelines.
+              </Text>
+
+              <Text fontWeight="bold">Analytics</Text>
+              <Text mb="3">
+                IOG may use Service Providers to monitor and analyze the use of
+                Products such as Matomo and/or PostHog.
+              </Text>
+
+              <Text fontWeight="bold">Newsletter</Text>
+              <Text mb="3">
+                If you would like to receive our newsletter, we require a valid
+                email address as well as information that allows us to verify
+                that you are the owner of the specified email address and that
+                you agree to receive this newsletter. No additional data is
+                collected or is only collected on a voluntary basis. We only use
+                this data to send the requested information and do not pass it
+                on to third parties. We will, therefore, process any data you
+                enter onto the contact form only with your consent per (Article
+                6 (1) (a) General Data Protection Regulation). You can revoke
+                consent to the storage and use of your data and email address
+                for sending the newsletter at any time, e.g., through the
+                "unsubscribe" link in the newsletter. The data processed before
+                we receive your request may still be legally processed. The data
+                provided when registering for the newsletter will be used to
+                distribute the newsletter until you cancel your subscription
+                when said data will be deleted. Data we have stored for other
+                purposes (e.g., email addresses for members areas) remain
+                unaffected.
+              </Text>
+
+              <Text fontWeight="bold">Newsletter Tracking</Text>
+              <Text mb="3">
+                Newsletter tracking (also referred to as Web beacons or tracking
+                pixels) is used if users have given their explicit prior
+                consent. When the newsletter is dispatched, the external server
+                can then record certain data related to the recipient, such as
+                the time and date the newsletter is retrieved, the IP address or
+                details regarding the email program (client) used. The name of
+                the image file is personalized for every email recipient by a
+                unique ID being appended to it. The sender of the email notes
+                which ID belongs to which email address and is thus able to
+                determine which newsletter recipient has just opened the email
+                when the image is called.
+              </Text>
+              <Text mb="4">
+                You may revoke your consent at any time by unsubscribing to the
+                newsletter. This can be done by sending an email request to
+                unsubscribe to{' '}
+                <Link href="mailto:dataprotection@iohk.io">
+                  dataprotection@iohk.io
+                </Link>
+                . You may also remove yourself from the mailing list using the
+                unsubscribe link in the newsletter.
+              </Text>
+              <Text mb="4" fontWeight="bold">
+                11. Links To Other Products
+              </Text>
+              <Text mb="3">
+                Products may contain links to other products that are not
+                operated by IOG. If you click on a third-party link, you will be
+                directed to that third party's site. You’re advised to review
+                the privacy policy of each non-IOG site you decide to visit.
+              </Text>
+              <Text mb="4">
+                IOG has no control over and assumes no responsibility for the
+                content, privacy policies, or practices of any third-party
+                product or service.
+              </Text>
+
+              <Text mb="4" fontWeight="bold">
+                12. Changes To This Privacy Policy
+              </Text>
+              <Text mb="3">
+                IOG may update this Privacy Policy from time to time. Such
+                changes will be posted on this page. The effective date of such
+                changes will be notified via email and/or a prominent notice on
+                the Product, with an update to the "effective date" at the top
+                of this Privacy Policy.
+              </Text>
+              <Text mb="3">
+                You are advised to review this Privacy Policy periodically for
+                any changes. Changes to this Privacy Policy are effective when
+                they are posted on this page.
+              </Text>
+
+              <Text mb="4" fontWeight="bold">
+                13. Data Privacy Contact
+              </Text>
+              <Text mb="4">
+                You can reach our data protection officer at{' '}
+                <Link href="mailto:dataprotection@iohk.io">
+                  dataprotection@iohk.io
+                </Link>
+                .
+              </Text>
+
+              <Text mb="4" fontWeight="bold">
+                14. Contact by E-mail or Contact Form
+              </Text>
+              <Text mb="3">
+                When you contact us by e-mail or through a contact form, we
+                store the data you provide (your email address, possibly your
+                name and telephone number) so we can answer your questions.
+                Insofar as we use our contact form to request entries that are
+                not required for contacting you, we have marked these as
+                optional. This information serves to substantiate your inquiry
+                and improve the handling of your request. Your message may be
+                linked to various actions taken by you on the IOG website.
+                Information collected will be solely used to provide you with
+                support relating to your inquiry and better understand your
+                feedback. A statement of this information is expressly provided
+                on a voluntary basis and with your consent. As far as this
+                concerns information about communication channels (such as
+                e-mail address or telephone number), you also agree that we may,
+                where appropriate, contact you via this communication channel to
+                answer your request. You may, of course, revoke this consent for
+                the future at any time.
+              </Text>
+              <Text mb="3">
+                We delete the data that arises in this context after saving is
+                no longer required, or limit processing if there are statutory
+                retention requirements.
+              </Text>
               <Box h="2" />
             </Box>
           </Scrollbars>

--- a/src/ui/app/components/privacyPolicy.jsx
+++ b/src/ui/app/components/privacyPolicy.jsx
@@ -196,8 +196,8 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
               <UnorderedList mb="3">
                 <ListItem>
                   IOG exercising its rights and performing its obligations in
-                  connection with any contract make with you (Article 6 (1) (b)
-                  General Data Protection Regulation),
+                  connection with any contract we make with you (Article 6 (1)
+                  (b) General Data Protection Regulation),
                 </ListItem>
                 <ListItem>
                   Compliance with IOG's legal obligations (Article 6 (1) (c)
@@ -296,7 +296,7 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
               </Text>
               <Text mb="3">
                 Insofar as we employ the services of service providers to
-                implement or fulfill any tasks on our behalf, the contractual
+                implement or fulfill any tasks on our behalf the contractual
                 relations will be regulated in writing according to the
                 provisions of the European General Data Protection Regulation
                 (EU-GDPR) and the Federal Data Protection Act (new BDSG).
@@ -311,8 +311,8 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
                 the processing of your enquiry. These offices are legally
                 obligated to abide by the EU-GDPR. Furthermore, between the
                 legally autonomous companies in the network of affiliated
-                companies, written agreements exist for the processing of data
-                on commission, based on standardized contract stipulations.
+                companies written agreements exist for the processing of data on
+                commission, based on standardized contract stipulations.
               </Text>
               <Text mb="4" fontWeight="bold">
                 7. Security Of Data
@@ -397,9 +397,9 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
                     The right to object.
                   </Text>{' '}
                   You have the right to object to your personal information
-                  being used for a particular purpose, and you can exercise
-                  these rights, for example, via an unsubscribe link at the
-                  bottom of any email.
+                  being used for a particular purpose and you can exercise these
+                  rights, for example, via an unsubscribe link at the bottom of
+                  any email.
                 </ListItem>
                 <ListItem>
                   <Text display="inline" fontWeight="bold">
@@ -413,7 +413,7 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
                     The right to data portability.
                   </Text>{' '}
                   You have the right to be provided with a copy of the
-                  information IOG has on you in a structured, machine-readable,
+                  information IOG has on you in a structured, machine readable
                   and commonly used format.
                 </ListItem>
                 <ListItem>
@@ -473,12 +473,12 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
               </Text>
 
               <Text mb="4" fontWeight="bold">
-                10. Service Providers, Plugins, and Tools
+                10. Service Providers, Plugins and Tools
               </Text>
               <Text mb="3">
-                IOG may employ third-party companies and individuals to
+                IOG may employ third party companies and individuals to
                 facilitate Products, to provide the Products on our behalf, to
-                perform website-related services, or to assist us in analyzing
+                perform website-related services or to assist us in analyzing
                 how the Products are used (
                 <Text display="inline" fontWeight="bold">
                   "Service Providers"
@@ -509,7 +509,7 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
                 profile. You can prevent this by logging out of your YouTube
                 account. YouTube is used to help make our website appealing. For
                 information about the scope and purpose of data collection, the
-                further processing and use of the data by YouTube, and your
+                further processing and use of the data by YouTube and your
                 rights and the settings you can configure to protect your
                 privacy, please refer to the YouTube Privacy Guidelines.
               </Text>
@@ -577,7 +577,7 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
               </Text>
               <Text mb="4">
                 IOG has no control over and assumes no responsibility for the
-                content, privacy policies, or practices of any third-party
+                content, privacy policies or practices of any third-party
                 product or service.
               </Text>
 
@@ -588,8 +588,8 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
                 IOG may update this Privacy Policy from time to time. Such
                 changes will be posted on this page. The effective date of such
                 changes will be notified via email and/or a prominent notice on
-                the Product, with an update to the "effective date" at the top
-                of this Privacy Policy.
+                the Product, with an update the "effective date" at the top of
+                this Privacy Policy.
               </Text>
               <Text mb="3">
                 You are advised to review this Privacy Policy periodically for
@@ -627,7 +627,7 @@ const PrivacyPolicy = React.forwardRef((props, ref) => {
                 concerns information about communication channels (such as
                 e-mail address or telephone number), you also agree that we may,
                 where appropriate, contact you via this communication channel to
-                answer your request. You may, of course, revoke this consent for
+                answer your request. You may of course revoke this consent for
                 the future at any time.
               </Text>
               <Text mb="3">

--- a/src/ui/app/components/termsOfUse.jsx
+++ b/src/ui/app/components/termsOfUse.jsx
@@ -9,6 +9,9 @@ import {
   ModalHeader,
   ModalOverlay,
   useDisclosure,
+  OrderedList,
+  ListItem,
+  Link,
 } from '@chakra-ui/react';
 import { Scrollbars } from './scrollbar';
 import { useCaptureEvent } from '../../../features/analytics/hooks';
@@ -43,421 +46,607 @@ const TermsOfUse = React.forwardRef((props, ref) => {
         <ModalBody pr="0.5">
           <Scrollbars style={{ width: '100%', height: '400px' }}>
             <Box width="92%">
-              <Text
-                mb="1"
-                fontSize="md"
-                fontWeight="bold"
-                id="terms-of-service-agreement"
-              >
-                Terms of Service Agreement
+              <Text mb="3">Last Updated: March 30, 2022</Text>
+              <Text mb="3">
+                These Terms of Use (
+                <Text display="inline" fontWeight="bold">
+                  "Terms"
+                </Text>
+                ) set forth the binding legal agreement between you and Input
+                Output Global, Inc. (together with our subsidiaries and
+                affiliates, referred to as{' '}
+                <Text display="inline" fontWeight="bold">
+                  "IOG,"
+                </Text>{' '}
+                <Text display="inline" fontWeight="bold">
+                  "we,"
+                </Text>{' '}
+                or{' '}
+                <Text display="inline" fontWeight="bold">
+                  "us"
+                </Text>{' '}
+                in this Agreement). These Terms govern your use of this website
+                and all of the related websites, mobile apps, products, and
+                services offered by IOG and its affiliated entities including
+                our plug-ins and browser extensions (collectively, the{' '}
+                <Text display="inline" fontWeight="bold">
+                  "Products"
+                </Text>
+                ).
               </Text>
-              <p>
-                THIS TERMS OF SERVICE AGREEMENT ("Agreement") is made between
-                Berry ("Cardano stake pool") and any person or entity ("User")
-                who completes the process to download, utilize, or operate the
-                software known as the Nami Wallet application, and data
-                processing service, application, communication service or other
-                content or offered or provided with the software by Berry. Berry
-                and User are collectively referred to as the "Parties." BY
-                CLICKING THE ACCEPTANCE BUTTON OR ACCESSING, USING OR INSTALLING
-                ANY PART OF THE SOFTWARE, USER EXPRESSLY AGREES TO AND CONSENTS
-                TO BE LEGALLY BOUND BY ALL OF THE TERMS OF THIS AGREEMENT. IF
-                USER DOES NOT AGREE TO ALL OF THE TERMS OF THIS AGREEMENT, THE
-                USER SHALL NOT BE AUTHORIZED TO ACCESS, USE OR INSTALL ANY PART
-                OF THE SOFTWARE.
-              </p>
-              <Text
-                fontWeight="bold"
-                mt="3"
-                mb="1"
-                id="1-rights-and-obligations"
-              >
-                1. Rights and Obligations
+              <Text mb="4">
+                We encourage you to review these Terms carefully. By accessing
+                or using the Products in any way, including browsing any
+                IOG-owned website, you are agreeing to these Terms in their
+                entirety. If you do not agree to any of the Terms, you may not
+                use the Products.
               </Text>
-              <p>
-                <span style={{ fontSize: 15 }}>a. Description.</span>&nbsp;The
-                Software functions as a free, open source, digital
-                cryptocurrency wallet. The Software does not constitute an
-                account by which Berry or any other third parties serve as
-                financial intermediaries or custodians of User's ADA or any
-                other cryptocurrency. While the Software has undergone beta
-                testing and continues to be improved by feedback from the
-                developers community, open-source contributors and beta-testers,
-                Berry cannot guarantee that there will be no bugs in the
-                Software. User acknowledges that User's use of the Software is
-                at User's risk, discretion and in compliance with all applicable
-                laws. User is responsible for safekeeping User's passwords,
-                PINs, private keys, redemption keys, shielded vending keys,
-                backup recovery mnemonic passphrases, ADA passcodes and any
-                other codes User uses to access the Software or any information,
-                ADA, voucher, or other cryptocurrency unit. IF USER LOSES ACCESS
-                TO USER'S CRYPTOCURRENCY WALLET OR PRIVATE KEYS AND HAS NOT
-                SEPARATELY STORED A BACKUP OF USER'S CRYPTOCURRENCY WALLET OR
-                BACKUP RECOVERY MNEMONIC PHRASE(S) AND CORRESPONDING
-                PASSWORD(S), USER ACKNOWLEDGES AND AGREES THAT ANY ADA OR ANY
-                OTHER CRYPTOCURRENCIES USER HAS ASSOCIATED WITH THAT
-                CRYPTOCURRENCY WALLET WILL BECOME INACCESSIBLE. All transaction
-                requests are irreversible. Berry and its shareholders,
-                directors, officers, employees, affiliates and agents cannot
-                guarantee transaction confirmation or retrieve User's private
-                keys or passwords if User loses or forgets them.
-              </p>
-              <p>
-                <span style={{ fontSize: 15 }}>b. Accessibility.</span>
-                &nbsp;User agrees that from time to time the Software may be
-                inaccessible or inoperable for any reason, including, without
-                limitation: (i) equipment malfunctions; (ii) periodic
-                maintenance procedures or repairs which Berry may undertake from
-                time to time; or (iii) causes beyond the control of the Berry or
-                which are not reasonably foreseeable by Berry.
-              </p>
-              <p>
-                <span style={{ fontSize: 15 }}>c. Equipment.</span>&nbsp;User
-                shall be solely responsible for providing, maintaining and
-                ensuring compatibility with the Software, all hardware,
-                software, electrical and other physical requirements for User's
-                use of the Software, including, without limitation,
-                telecommunications and internet access connections and links,
-                web browsers or other equipment, programs and services required
-                to access and use the Software.
-              </p>
-              <p>
-                <span style={{ fontSize: 15 }}>d. Security.</span>&nbsp;User
-                shall be solely responsible for the security, confidentiality
-                and integrity of all information and content that User receives,
-                transmits through or stores on the Software. User shall be
-                solely responsible for any authorized or unauthorized access to
-                any account of User by any person. User agrees to bear all
-                responsibility for the confidentiality of User's security
-                devices, information, keys, and passwords.
-              </p>
-              <p>
-                <span style={{ fontSize: 15 }}>e. Privacy.</span>&nbsp;When
-                reasonably practicable, Berry will attempt to respect User's
-                privacy. Berry will not monitor, edit, or disclose any personal
-                information about User or User's account, including its contents
-                or User's use of the Software, without User's prior consent
-                unless Berry believes in good faith that such action is
-                necessary to: (i) comply with legal process or other legal
-                requirements of any governmental authority; (ii) protect and
-                defend the rights or property Berry; (iii) enforce this
-                Agreement; (iv) protect the interests of users of the Software
-                other than User or any other person; or (v) operate or conduct
-                maintenance and repair of Berry's services or equipment,
-                including the Software as authorized by law. User has no
-                expectation of privacy with respect to the Internet generally.
-                User's IP address is transmitted and recorded with each message
-                or other information User sends from the Software.
-              </p>
-              <Text fontWeight="bold" mt="3" mb="1" id="2-taxes-and-fees">
-                2. Taxes and Fees
+              <Text fontWeight="bold">1. Using the Products.</Text>
+              <OrderedList mb="3" pl="2" listStyleType="lower-alpha">
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Who can use the Products.
+                  </Text>{' '}
+                  You must be at least the age of majority in the jurisdiction
+                  where you live to use the Products.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Product Changes.
+                  </Text>{' '}
+                  We reserve the right to make changes or updates to Products,
+                  including content and formatting, at any time without notice.
+                  We reserve the right to terminate or restrict access to the
+                  Products (including any accounts you may have created through
+                  your use of the Products) for any reason whatsoever at our
+                  sole discretion.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Privacy Policy.
+                  </Text>{' '}
+                  Our privacy practices are set forth in our{' '}
+                  <Link
+                    color="teal"
+                    isExternal
+                    textDecoration="underline"
+                    onClick={() =>
+                      window.open(
+                        'https://static.iohk.io/terms/iog-privacy-policy.pdf'
+                      )
+                    }
+                  >
+                    Privacy Policy
+                  </Link>
+                  . By using the Products in any way, you understand and
+                  acknowledge that the terms of the Privacy Policy apply to you.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Additional Terms.
+                  </Text>{' '}
+                  Specific terms and conditions may apply to specific content,
+                  products, materials, services, or information contained on or
+                  available through various Products or transactions concluded
+                  through the Products. Such specific terms may be in addition
+                  to these Terms or, where inconsistent with these Terms, only
+                  to the extent the content or intent of such specific terms is
+                  inconsistent with these Terms, such specific terms will
+                  supersede these Terms.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Feedback.
+                  </Text>{' '}
+                  We welcome your feedback and suggestions about how to improve
+                  the Products. Feel free to submit feedback at{' '}
+                  <Link
+                    isExternal
+                    onClick={() => window.open('https://iohk.io/en/contact/')}
+                  >
+                    https://iohk.io/en/contact/
+                  </Link>
+                  . By submitting feedback in this or any other manner to us,
+                  you grant us the right, at our discretion, to use, disclose,
+                  and otherwise exploit the feedback, in whole or part, without
+                  any restriction or compensation to you, as further described
+                  in Section 2(b) below.
+                </ListItem>
+              </OrderedList>
+              <Text fontWeight="bold">2. Your Content</Text>
+              <OrderedList mb="3" pl="2" listStyleType="lower-alpha">
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Definition of Your Content.
+                  </Text>{' '}
+                  The Products may enable you to post materials, including
+                  without limitation photos, profile pictures, messages,
+                  comments, and testimonials. You may also post reviews of
+                  third-party service providers, third-party products, or
+                  third-party services. All materials that you post on the
+                  Products will be referred to collectively as{' '}
+                  <Text fontWeight="bold" display="inline">
+                    "Your Content."
+                  </Text>
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    License and Permission to Use Your Content.
+                  </Text>{' '}
+                  You hereby grant to us and our affiliates, licensees and
+                  sublicensees, without compensation to you or others, a
+                  nonexclusive, perpetual, irrevocable, royalty-free, fully
+                  paid-up, worldwide license (including the right to sublicense
+                  through multiple tiers) to use, reproduce, process, adapt,
+                  publicly perform, publicly display, modify, prepare derivative
+                  works, publish, transmit and distribute Your Content, or any
+                  portion thereof, throughout the world in any format, media or
+                  distribution method (whether now known or hereafter created)
+                  for the duration of any copyright or other rights in Your
+                  Content. Such permission will be perpetual and may not be
+                  revoked for any reason, to the maximum extent permitted by
+                  law. Further, to the extent permitted under applicable law,
+                  you waive and release and covenant not to assert any moral
+                  rights that you may have in Your Content. If you identify
+                  yourself by name or provide a picture or audio or video
+                  recording of yourself, you further authorize us and our
+                  affiliates, licensees and sublicensees, without compensation
+                  to you or others, to reproduce, print, publish and disseminate
+                  in any format or media (whether now known or hereafter
+                  created) your name, voice and likeness throughout the world,
+                  and such permission will be perpetual and cannot be revoked
+                  for any reason, except as required by applicable law. You
+                  further agree that we may use Your Content in any manner that
+                  we deem appropriate or necessary, including but not limited to
+                  IOG Business Purposes.{' '}
+                  <Text fontWeight="bold" display="inline">
+                    "IOG Business Purposes"
+                  </Text>{' '}
+                  means any use in connection with a Product or IOG co-branded
+                  website, application, publication or service, or any use which
+                  advertises, markets or promotes Products, the services or the
+                  information within the Products, IOG, or its affiliates. IOG
+                  Business Purpose specifically includes the use of Your Content
+                  within the Products in connection with features and functions
+                  offered by IOG to our users that enable them to view and
+                  interact with Your Content (such as DApp reviews).
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Ownership.
+                  </Text>{' '}
+                  We acknowledge and agree that you, or your licensors, as
+                  applicable, retain ownership of any and all copyrights in Your
+                  Content, subject to the non-exclusive rights granted to us in
+                  the paragraph above, and that no ownership of such copyrights
+                  is transferred to us under these Terms, except as may
+                  otherwise be provided in these Terms or another agreement
+                  between you and IOG.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Your Responsibilities for Your Content.
+                  </Text>{' '}
+                  By posting, uploading, or submitting Your Content to any
+                  Products, you represent and warrant to us that you have the
+                  ownership rights, or you have obtained all necessary licenses
+                  or permissions from any relevant parties, to use Your Content
+                  in this manner. This includes obtaining the right to grant us
+                  the rights to use Your Content in accordance with these Terms.
+                  You are in the best position to judge whether Your Content is
+                  in violation of intellectual property or personal rights of
+                  any third-party.{' '}
+                  <Text fontWeight="bold" display="inline">
+                    You accept full responsibility for avoiding infringement of
+                    the intellectual property or personal rights of others in
+                    connection with Your Content.
+                  </Text>{' '}
+                  You are responsible for ensuring that Your Content does not
+                  violate any applicable law or regulation, including but not
+                  limited to the intellectual property rights of any third
+                  party. You agree to pay all royalties, fees, and any other
+                  monies owed to any person by reason of Your Content.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Limits.
+                  </Text>{' '}
+                  We reserve the right to remove Your Content, in whole or part,
+                  for any reason without notice. We do not guarantee that we
+                  will publish any or all of Your Content.
+                </ListItem>
+              </OrderedList>
+              <Text fontWeight="bold">3. Our Content and Materials</Text>
+              <OrderedList mb="3" pl="2" listStyleType="lower-alpha">
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Definition of Our Content and Materials.
+                  </Text>{' '}
+                  All intellectual property in or related to the Products
+                  (specifically including, but not limited to, our software, the
+                  IOG marks, the IOG logos) (
+                  <Text fontWeight="bold" display="inline">
+                    "Our Content and Materials"
+                  </Text>
+                  ) is the property of IOG.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Our License to You.
+                  </Text>{' '}
+                  Subject to these Terms of Use, including the restrictions
+                  below, we grant you a limited non-exclusive license to use and
+                  access Our Content and Materials in connection with your use
+                  of the Products. Except as expressly agreed to otherwise by us
+                  (such as your entering into another other agreement with us),
+                  your use of the Products must be limited to personal,
+                  non-commercial use. We may terminate this license at any time
+                  for any reason. Except for the rights and license granted in
+                  these Terms, we reserve all other rights and grant no other
+                  rights or licenses, implied or otherwise. Notwithstanding the
+                  foregoing, some content may be subject to open-source
+                  licenses, in which case the specific license(s) mentioned in
+                  connection with such content shall apply.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Restrictions.
+                  </Text>{' '}
+                  Except as expressly provided in these Terms, you agree not to
+                  use, modify, reproduce, distribute, sell, license, reverse
+                  engineer, decompile, or otherwise exploit Our Content and
+                  Materials without our express written permission. Your
+                  permitted use of the Products expressly excludes commercial
+                  use by you of any product descriptions for the benefit of
+                  another merchant. You are expressly prohibited from any use of
+                  data mining, robots, or similar data gathering and extraction
+                  tools in your use of the Products. You may view and print a
+                  reasonable number of copies of web pages located on the
+                  Products for your own personal use, provided that you retain
+                  all proprietary notices contained in the original materials,
+                  including attribution to IOG. We have no obligation to delete
+                  content that you personally may find objectionable or
+                  offensive.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Ownership.
+                  </Text>{' '}
+                  You acknowledge and agree that the Products and IOG marks will
+                  remain the property of IOG. The content, information and
+                  services made available on the Products are protected by U.S.
+                  and international copyright, trademark, and other laws, and
+                  you acknowledge that these rights are valid and enforceable.
+                  You acknowledge that you do not acquire any ownership rights
+                  by using or interacting with the Products.
+                </ListItem>
+              </OrderedList>
+              <Text fontWeight="bold">4. Other Offerings on the Products</Text>
+              <OrderedList mb="3" pl="2" listStyleType="lower-alpha">
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Third-Party Services.
+                  </Text>{' '}
+                  Please note that the Products may enable access to third-party
+                  content, products, and services, and may offer interactions
+                  with third parties that we do not control (collectively{' '}
+                  <Text fontWeight="bold" display="inline">
+                    "Third-Party Services"
+                  </Text>
+                  ). The availability of any Third-Party Services on the
+                  Products does not imply our endorsement or verification of the
+                  Third-Party Services. We assume no responsibility for, nor do
+                  we endorse or verify the content, offerings, or conduct of
+                  third parties (including but not limited to the products or
+                  services offered by third parties or the descriptions of the
+                  products or services offered by third parties). We make no
+                  warranties or representations with respect to the accuracy,
+                  completeness, or timeliness of any content posted on or in the
+                  Products by anyone.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Third-Party Sites.
+                  </Text>{' '}
+                  The Products may contain links to other websites (the{' '}
+                  <Text fontWeight="bold" display="inline">
+                    "Third-Party Sites"
+                  </Text>
+                  ) for your convenience. We do not control the linked websites
+                  or the content provided through such Third-Party Sites. Your
+                  use of Third-Party Sites is subject to the privacy practices
+                  and terms of use established by the specific linked
+                  Third-Party Site, and we disclaim all liability for such use.
+                  The availability of such links does not indicate any approval
+                  or endorsement by us.
+                </ListItem>
+              </OrderedList>
+              <Text fontWeight="bold">
+                5. Reporting Violations of Your Intellectual Property Rights.
               </Text>
-              <p>
-                All currency conversion charges, third party fees, sales, use,
-                value-added, personal property or other tax, duty or levy of any
-                kind, including interest and penalties thereon, whether imposed
-                now or hereinafter by any governmental entity, and fees incurred
-                by User by reason of User's access, use or installation of the
-                Software shall be the sole responsibility of User.
-              </p>
-              <Text fontWeight="bold" mt="3" mb="1" id="3-user-representations">
-                3. User Representations
+              <Text mb="3">
+                For information about how to submit a request for takedown if
+                you believe content on the Products infringes your intellectual
+                property rights, please read our{' '}
+                <Link
+                  color="teal"
+                  isExternal
+                  textDecoration="underline"
+                  onClick={() =>
+                    window.open(
+                      'https://static.iohk.io/terms/iog-dmca-policy.pdf'
+                    )
+                  }
+                >
+                  Digital Millennium Copyright Act (DMCA) Policy
+                </Link>
+                . We endeavor to respond promptly to requests for content
+                removal, consistent with our policies described above and
+                applicable law.
               </Text>
-              <p>
-                User represents and warrants to Berry that: (a) if User is a
-                natural person, User is over the age of eighteen (18); (b) User
-                has the power and authority to enter into and perform User's
-                obligations under this Agreement; (c) all information provided
-                by User to Berry is truthful, accurate and complete; (d) User
-                will comply with all laws and regulations of any applicable
-                jurisdiction with regard to User's access, use or installation
-                of the Software; (e) User shall comply with all terms and
-                conditions of this Agreement, including, without limitation, the
-                provisions set forth at Section 4; and (f) User has provided and
-                will provide accurate and complete information as required for
-                access, use or installation of the Software.
-              </p>
-              <Text fontWeight="bold" mt="3" mb="1" id="4-prohibited-uses">
-                4. Prohibited Uses
+              <Text fontWeight="bold">
+                6. Disclaimers and Limitations of Liability.
               </Text>
-              <p>
-                User is solely responsible for any and all acts and omissions
-                that occur under User's account, security information, keys or
-                password, and User agrees not to engage in unacceptable use of
-                the Software, which includes, without limitation, use of the
-                Software to: (a) disseminate, store or transmit unsolicited
-                messages, chain letters or unsolicited commercial email; (b)
-                disseminate or transmit material that, to a reasonable person
-                may be abusive, obscene, pornographic, defamatory, harassing,
-                grossly offensive, vulgar, threatening or malicious; (c)
-                disseminate, store or transmit files, graphics, software or
-                other material that actually or potentially infringes the
-                copyright, trademark, patent, trade secret or other intellectual
-                property right of any person; (d) create a false identity or to
-                otherwise attempt to mislead any person as to the identity or
-                origin of any communication; (e) export, re-export or permit
-                downloading of any message or content in violation of any export
-                or import law, regulation or restriction of any applicable
-                jurisdiction, or without all required approvals, licenses or
-                exemptions; (f) interfere, disrupt or attempt to gain
-                unauthorized access to other accounts on the Software or any
-                other computer network; or (g) disseminate, store or transmit
-                viruses, Trojan horses or any other malicious code or program.
-              </p>
-              <Text fontWeight="bold" mt="3" mb="1" id="5-termination">
-                5. Termination
+              <Text mb="3" fontWeight="bold">
+                PLEASE READ THIS SECTION CAREFULLY SINCE IT LIMITS THE LIABILITY
+                OF IOG ENTITIES TO YOU.
               </Text>
-              <p>
-                This Agreement is effective upon User's acceptance as set forth
-                herein and shall continue in full force so long as User engages
-                in any access, use or installation of the Software. The Company
-                reserves the right, in its sole discretion and without notice,
-                at any time and for any reason, to: (a) remove or disable access
-                to all or any portion of the Software; (b) suspend User's access
-                to or use of all or any portion of the Software; and (c)
-                terminate this Agreement.
-              </p>
-              <Text
-                fontWeight="bold"
-                mt="3"
-                mb="1"
-                id="6-disclaimer-of-warranties"
-              >
-                6. Disclaimer of Warranties
+              <Text mb="2">
+                THE "IOG ENTITIES" MEANS IO GLOBAL, INC., IOG SINGAPORE PTE.
+                LTD. AND ANY SUBSIDIARIES, AFFILIATES, RELATED COMPANIES,
+                SUPPLIERS, LICENSORS AND PARTNERS, AND THE OFFICERS, DIRECTORS,
+                EMPLOYEES, AGENTS AND REPRESENTATIVES OF EACH OF THEM. EACH
+                PROVISION BELOW APPLIES TO THE MAXIMUM EXTENT PERMITTED UNDER
+                APPLICABLE LAW:
               </Text>
-              <p>
-                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-                EXPRESS OR IMPLIED. USE OF THE SOFTWARE IS AT USER'S SOLE RISK.
-                BERRY DOES NOT WARRANT THAT THE SOFTWARE WILL BE UNINTERRUPTED
-                OR ERROR FREE, NOR DOES BERRY MAKE ANY WARRANTY AS TO ANY
-                RESULTS THAT MAY BE OBTAINED BY USE OF THE SOFTWARE. BERRY MAKES
-                NO OTHER WARRANTIES, EXPRESS OR IMPLIED. BERRY EXPRESSLY
-                DISCLAIMS ANY WARRANTY OF MERCHANTABILITY, WARRANTY OF
-                SUITABILITY FOR A PARTICULAR PURPOSE, WARRANTY OF TITLE OR
-                INTEREST, OR WARRANTY OF NONINFRINGEMENT.
-              </p>
-              <Text
-                fontWeight="bold"
-                mt="3"
-                mb="1"
-                id="7-limitation-of-liability"
-              >
-                7. Limitation of Liability
+              <OrderedList mb="3" pl="2" listStyleType="lower-alpha">
+                <ListItem>
+                  WE ARE PROVIDING YOU THE PRODUCTS, SERVICES, INFORMATION, OUR
+                  CONTENT AND MATERIALS, PRODUCT DESCRIPTIONS, AND THIRD-PARTY
+                  CONTENT ON AN "AS IS" AND "AS AVAILABLE" BASIS, WITHOUT
+                  WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. WITHOUT LIMITING THE
+                  FOREGOING, THE IOG ENTITIES EXPRESSLY DISCLAIM ANY AND ALL
+                  WARRANTIES AND CONDITIONS OF MERCHANTABILITY, TITLE, ACCURACY
+                  AND COMPLETENESS, UNINTERRUPTED OR ERROR-FREE SERVICE, FITNESS
+                  FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT, AND
+                  NON-INFRINGEMENT, AND ANY WARRANTIES ARISING OUT OF COURSE OF
+                  DEALING OR TRADE USAGE. NOTHING CONTAINED IN THE PRODUCTS IS
+                  INTENDED TO BE LEGAL, FINANCIAL, OR TAX ADVICE.
+                </ListItem>
+                <ListItem>
+                  THE IOG ENTITIES MAKE NO PROMISES WITH RESPECT TO, AND
+                  EXPRESSLY DISCLAIM ALL LIABILITY, TO THE MAXIMUM EXTENT
+                  PERMITTED BY LAW, FOR: (i) CONTENT POSTED BY ANY THIRD-PARTY
+                  ON THE PRODUCTS, (ii) THE PRODUCT DESCRIPTIONS OR PRODUCTS,
+                  (iii) THIRD-PARTY SITES AND ANY THIRD-PARTY PRODUCT OR SERVICE
+                  LISTED ON OR ACCESSIBLE TO YOU THROUGH THE IOG PRODUCTS, AND
+                  (iv) THE QUALITY OR CONDUCT OF ANY THIRD PARTY YOU ENCOUNTER
+                  IN CONNECTION WITH YOUR USE OF THIS WEBSITE OR ANY IOG
+                  PRODUCT.
+                </ListItem>
+                <ListItem>
+                  THE IOG ENTITIES DO NOT WARRANT OR MAKE ANY REPRESENTATIONS AS
+                  TO THE SECURITY OF ANY OF ITS WEBSITES. YOU ACKNOWLEDGE ANY
+                  INFORMATION SENT THROUGH A WEBSITE MAY BE INTERCEPTED. THE IOG
+                  ENTITIES DO NOT WARRANT THAT ITS WEBSITES OR THE SERVERS WHICH
+                  MAKE THIS WEBSITE AVAILABLE OR ELECTRONIC COMMUNICATIONS SENT
+                  BY IOG ENTITIES ARE FREE FROM VIRUSES OR ANY OTHER HARMFUL
+                  ELEMENTS. THE IOG ENTITIES DO NOT WARRANT THAT ANY E-MAIL OR
+                  OTHER ELECTRONIC CORRESPONDENCE BEING SENT TO IOG WILL BE
+                  TIMELY RECEIVED OR PROCESSED. THE IOG ENTITIES SHALL IN NO
+                  EVENT BE LIABLE FOR ANY CONSEQUENCES OF NOT TIMELY RECEIVING
+                  OR PROCESSING ANY E-MAIL OR OTHER ELECTRONIC CORRESPONDENCE.
+                </ListItem>
+                <ListItem>
+                  YOU AGREE THAT TO THE MAXIMUM EXTENT PERMITTED BY LAW, THE IOG
+                  ENTITIES WILL NOT BE LIABLE TO YOU UNDER ANY THEORY OF
+                  LIABILITY. WITHOUT LIMITING THE FOREGOING, YOU AGREE THAT THE
+                  IOG ENTITIES SPECIFICALLY WILL NOT BE LIABLE FOR (i) ANY
+                  INDIRECT, INCIDENTAL, CONSEQUENTIAL, SPECIAL, INCIDENTAL OR
+                  EXEMPLARY DAMAGES, LOSS OF PROFITS, LOSS OF BUSINESS, BUSINESS
+                  INTERRUPTION, REPUTATIONAL HARM, OR LOSS OF DATA (EVEN IF THE
+                  IOG ENTITIES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH
+                  DAMAGES OR SUCH DAMAGES ARE FORESEEABLE) ARISING OUT OF AND IN
+                  ANY WAY CONNECTED WITH YOUR USE OF, OR INABILITY TO USE, THIS
+                  WEBSITE OR ANY IOG PRODUCTS OR (ii) ANY AMOUNT, IN THE
+                  AGGREGATE, IN EXCESS OF ONE-HUNDRED DOLLARS (USD$100). YOUR
+                  USE OF THE PRODUCTS, INFORMATION, OR SERVICES IS AT YOUR SOLE
+                  RISK.
+                </ListItem>
+              </OrderedList>
+              <Text fontWeight="bold">7. Indemnification.</Text>
+              <Text mb="3">
+                You agree to fully indemnify, defend, and hold the IOG Entities
+                and their directors, officers, employees, consultants, and other
+                representatives, harmless from and against any and all claims,
+                damages, losses, costs (including reasonable attorneys' fees),
+                and other expenses that arise directly or indirectly out of or
+                from: (a) your breach of any part of these Terms, including but
+                not limited to any policies referenced herein; (b) any
+                allegation that any materials you submit to us or transmit to
+                the Products infringe or otherwise violate the copyright,
+                patent, trademark, trade secret, or other intellectual property
+                or other rights of any third party; (c) your activities in
+                connection with the Products or other websites to which the
+                Products are linked; and/or (d) your negligent or willful
+                misconduct.
               </Text>
-              <p>
-                IN NO EVENT SHALL BERRY OR ITS SHAREHOLDERS, DIRECTORS,
-                OFFICERS, EMPLOYEES, AFFILIATES OR AGENTS, OR ANY OF ITS OR
-                THEIR RESPECTIVE SERVICE PROVIDERS, BE LIABLE TO USER OR ANY
-                THIRD PARTY FOR ANY USE, INTERRUPTION, DELAY OR INABILITY TO USE
-                THE SOFTWARE, LOST REVENUES OR PROFITS, DELAYS, INTERRUPTION OR
-                LOSS OF SERVICES, BUSINESS OR GOODWILL, LOSS OR CORRUPTION OF
-                DATA, LOSS RESULTING FROM SYSTEM OR SYSTEM SERVICE FAILURE,
-                MALFUNCTION OR SHUTDOWN, FAILURE TO ACCURATELY TRANSFER, READ OR
-                TRANSMIT INFORMATION, FAILURE TO UPDATE OR PROVIDE CORRECT
-                INFORMATION, SYSTEM INCOMPATIBILITY OR PROVISION OF INCORRECT
-                COMPATIBILITY INFORMATION OR BREACHES IN SYSTEM SECURITY, OR FOR
-                ANY CONSEQUENTIAL, INCIDENTAL, INDIRECT, EXEMPLARY, SPECIAL OR
-                PUNITIVE DAMAGES, WHETHER ARISING OUT OF OR IN CONNECTION WITH
-                THIS AGREEMENT, BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE)
-                OR OTHERWISE, REGARDLESS OF WHETHER SUCH DAMAGES WERE
-                FORESEEABLE AND WHETHER OR NOT WE WERE ADVISED OF THE
-                POSSIBILITY OF SUCH DAMAGES. IN NO EVENT SHALL BERRY OR ITS
-                SHAREHOLDERS, DIRECTORS, OFFICERS, EMPLOYEES, AFFILIATES OR
-                AGENTS, OR ANY OF ITS OR THEIR RESPECTIVE SERVICE PROVIDERS, BE
-                LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-                ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM OR IN ANY
-                WAY RELATED TO USER'S ACCESS, USE OR INSTALLATION OF THE
-                SOFTWARE. SOME JURISDICTIONS PROHIBIT THE EXCLUSION OR
-                LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, THUS THIS
-                LIMITATION OF LIABILITY MAY NOT APPLY TO USER. IF USER IS
-                DISSATISFIED WITH THE SOFTWARE, USER'S SOLE AND EXCLUSIVE REMEDY
-                SHALL BE FOR USER TO DISCONTINUE USE OF THE SOFTWARE.
-              </p>
-              <Text fontWeight="bold" mt="3" mb="1" id="8-indemnification">
-                8. Indemnification
+              <Text fontWeight="bold">8 .Dispute Resolution.</Text>
+              <Text mb="3">
+                If you have a dispute with IOG, you agree to contact us using
+                the form at{' '}
+                <Link
+                  isExternal
+                  onClick={() => window.open('https://iohk.io/en/contact/')}
+                >
+                  https://iohk.io/en/contact/
+                </Link>{' '}
+                to attempt to resolve the issue informally first.
               </Text>
-              <p>
-                User agrees to indemnify, hold harmless and defend Berry, its
-                shareholders, directors, officers, employees, affiliates and
-                agents ("Indemnified Parties") from and against any action,
-                cause, claim, damage, debt, demand or liability, including
-                reasonable costs and attorney's fees, asserted by any person,
-                arising out of or relating to: (a) this Agreement; (b) User's
-                access, use or installation of the Software, including any data
-                or work transmitted or received by User; and (c) any
-                unacceptable use of the Software by any person, including,
-                without limitation, any statement, data or content made,
-                transmitted or republished by User or any person which is
-                prohibited as unacceptable under Section 4. THIS INDEMNIFICATION
-                INCLUDES THE EXPRESS INDEMNIFICATION OF BERRY AND ALL
-                INDEMNIFIED PARTIES FOR ANY ALLEGED NEGLIGENCE (INCLUDING ANY
-                ALLEGED GROSS NEGLIGENCE). OR OTHER ALLEGED MISCONDUCT OF BERRY
-                OR ANY INDEMNIFIED PARTIES.
-              </p>
-              <Text
-                fontWeight="bold"
-                mt="3"
-                mb="1"
-                id="9-intellectual-property"
-              >
-                9. Intellectual Property
+              <Text fontWeight="bold">9. Communications.</Text>
+              <Text fontWeight="bold" display="inline">
+                You are not required to agree to receive promotional text
+                messages, calls or prerecorded messages as a condition of using
+                the Products.
+              </Text>{' '}
+              <Text>
+                By electing to submit your phone number to us and agreeing to
+                these Terms, you agree to receive communications from the IOG
+                Entities, including via text messages, calls, pre-recorded
+                messages, and push notifications, any of which may be generated
+                by automatic telephone dialing systems. These communications
+                include, for example, operational communications concerning your
+                account or use of the Products, updates concerning new and
+                existing features on the Products, communications concerning
+                promotions run by us or third parties, and news relating to the
+                Products and industry developments. Standard text message
+                charges applied by your telephone carrier may apply to text
+                messages we send. If you submit someone else's phone number or
+                email address to us to receive communications from the IOG
+                Entities, you represent and warrant that each person for whom
+                you provide a phone number or email address has consented to
+                receive communications from IOG.
+                <Text fontWeight="bold" mb="3">
+                  If you wish to stop receiving promotional emails or
+                  promotional text messages, we provide the following methods
+                  for you to opt-out or unsubscribe: (a) follow the instructions
+                  we provide in the email or initial text message for that
+                  category of promotional emails or text messages or (b) if you
+                  have an account on the Products, you may opt-out or
+                  unsubscribe using your settings.
+                </Text>
               </Text>
-              <p>
-                Berry retains all right, title, and interest in and to all of
-                Berry's brands, logos, and trademarks, including, but not
-                limited to Berry, Berry Pool, Nami, Nami Wallet, Nami App, and
-                variations of the wording of the aforementioned brands, logos,
-                and trademarks.
-              </p>
-              <Text fontWeight="bold" mt="3" mb="1" id="10-warnings">
-                10. Warnings
-              </Text>
-              <p>
-                User acknowledges that Berry shall not be responsible for
-                transferring, safeguarding, or maintaining private keys and/or
-                User's ADA or any other cryptocurrency. If User and/or any
-                co-signing authorities lose, mishandle, or have stolen
-                associated private keys, or if User's cosigners refuse to
-                provide requisite authority, User acknowledges that User may not
-                be able to recover User's ADA or any other cryptocurrency, and
-                that Berry shall not be responsible for such loss.
-              </p>
-              <p>
-                User acknowledges and agrees that ADA or any other
-                cryptocurrency transactions facilitated by the Software and/or
-                Berry may be delayed, and that Berry shall not be responsible
-                for any associated loss. User acknowledges and agrees that Berry
-                shall not be responsible for any aspect of the information,
-                content, or services contained in any third-party materials or
-                on any third party sites accessible or linked to the Software
-                and/or Berry.
-              </p>
-              <p>
-                By using the Software, User acknowledges and agrees: (i) that
-                Berry is not responsible for the operation of the underlying
-                protocols and that Berry makes no guarantee of their
-                functionality, security, or availability; and (ii) that the
-                underlying protocols are subject to sudden main-chain changes in
-                operating rules ("forks"), and that such forks may materially
-                affect the value, and/or function of the ADA or any other
-                cryptocurrency that User stores on the Software. In the event of
-                a fork, User agrees that Berry may temporarily suspend the
-                Software operations (with or without notice to User) and that
-                Berry may, in its sole discretion, (a) configure or reconfigure
-                its systems or (b) decide not to support (or cease supporting)
-                the forked protocol entirely, provided, however, that User will
-                have an opportunity to withdraw funds from the Software. User
-                acknowledges and agrees that Berry assumes absolutely no
-                responsibility whatsoever in respect of an unsupported branch of
-                a forked protocol.
-              </p>
-              <Text fontWeight="bold" mt="3" mb="1" id="11-miscellaneous">
-                11. Miscellaneous
-              </Text>
-              <p>
-                <span style={{ fontSize: 15 }}>a. Amendment.</span>&nbsp;Berry
-                shall have the right, at any time and without notice, to add to
-                or modify the terms of this Agreement, simply by delivering such
-                amended terms to User by electronic message through any medium
-                to any address provided to Berry by User. User's access to or
-                use of the Software after the date such amended terms are
-                delivered to User shall be deemed to constitute acceptance of
-                such amended terms.
-              </p>
-              <p>
-                <span style={{ fontSize: 15 }}>b. Severance.</span>&nbsp;If any
-                provision or part-provision of this Agreement is, or becomes
-                invalid, illegal or unenforceable, it shall be deemed modified
-                to the minimum extent necessary to make it valid, legal and
-                enforceable. If such modification is not possible, the relevant
-                provision or part-provision shall be deemed deleted. Any
-                modification to or deletion of a provision or part-provision
-                under this Article shall not affect the validity and
-                enforceability of the rest of this Agreement.
-              </p>
-              <p>
-                <span style={{ fontSize: 15 }}>
-                  c. Entire Agreement &ndash; Disclaimer of Reliance
-                </span>
-                . This Agreement constitutes the entire agreement between the
-                Parties with respect to the subject matter hereof and supersedes
-                all prior agreements or understandings between the Parties. User
-                expressly represents and warrants that it is not relying upon
-                any statements, understandings, representations, expectations or
-                agreements other than those expressly set forth in this
-                Agreement.
-              </p>
-              <p>
-                <span style={{ fontSize: 15 }}>
-                  d. THIS AGREEMENT IS SUBJECT TO BINDING ARBITRATION.
-                </span>
-                &nbsp;User agrees that any and all disputes or claims against
-                any person arising out of or in any way related to this
-                Agreement or the access, use or installation of the Software by
-                User or any other person shall be subject to binding arbitration
-                under the Rules of Arbitration of the International Chamber of
-                Commerce by one or more arbitrators appointed in accordance with
-                the said Rules. The location of the arbitration shall be Japan.
-                The language of the arbitration shall be English.
-              </p>
-              <p>
-                <span style={{ fontSize: 15 }}>e. LANGUAGE.</span>&nbsp;Any
-                translation of this Agreement is made for purposes of local
-                reference only and in the event of any inconsistency between the
-                English and any non-English versions, the English version of
-                this Agreement shall prevail and govern in all respects.
-              </p>
-              <Text
-                fontWeight="bold"
-                mt="3"
-                mb="1"
-                id="12-delegation-and-staking"
-              >
-                12. Delegation and Staking
-              </Text>
-              <p>
-                12.1&nbsp;<span style={{ fontSize: 15 }}>Rewards.</span>
-                &nbsp;The amount of Rewards a User may earn from delegation
-                depends on various factors including, but not limited to, user
-                participation, stakepool profit margins and the volume of ada
-                being delegated. It is possible that delegation generates no
-                Reward for a User due to the above-mentioned factors. Rewards
-                are earned as of the start of the 3rd epoch on the Cardano
-                blockchain.
-              </p>
-              <p>
-                12.2&nbsp;<span style={{ fontSize: 15 }}>Delegation.</span>
-                &nbsp;Users may delegate their stake to one of the various stake
-                pools of Berry or to a third party stake pool. User will have
-                the sole right to determine the volume to be delegated to a
-                stake pool and may increase or decrease its level of
-                participation at any time. Any information Berry shares
-                regarding stakepools, including Rewards, will be for indicative
-                purposes only and may not be accurate. Users may only delegate
-                their stake to a stake pool if their ada is in an updated Nami
-                Wallet at the time of the setup process. User does not acquire
-                any automatic right to Rewards as a result of delegating its
-                stake.
-              </p>
-              <p>
-                12.3&nbsp;<span style={{ fontSize: 15 }}>Berry Pool</span>
-                &nbsp;Berry operates the Berry stake pool which will be visible
-                in Nami. The cost and network and server requirements to
-                reliably operate such stake pools shall be determined by Berry
-                in its sole discretion. Berry will communicate the percentage
-                amount of Reward to be shared with Users through the
-                User&rsquo;s Nami wallet. Rewards will accrue at the end of each
-                epoch and will automatically appear in the User&rsquo;s Nami
-                wallet.
-              </p>
-              <p>
-                12.4&nbsp;
-                <span style={{ fontSize: 15 }}>Redeeming Rewards.</span>
-                &nbsp;User shall be responsible for payment of all applicable
-                taxes, if any, to which the Rewards might be subject and any and
-                all other taxes which may apply to User once Rewards are
-                redeemed.
-              </p>
+              <Text fontWeight="bold">10. Miscellaneous.</Text>
+              <OrderedList mb="3" pl="2" listStyleType="lower-alpha">
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Application Provider Terms.
+                  </Text>{' '}
+                  If you access the Products through an IOG application, you
+                  acknowledge that these Terms are between you and IOG only, and
+                  not with an application service or application platform
+                  provider (such as Apple, Inc., or Google Inc.), which may
+                  provide you the application subject to its own terms of use.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Controlling Law and Jurisdiction.
+                  </Text>{' '}
+                  These Terms will be interpreted in accordance with the laws of
+                  the State of New York and the United States of America,
+                  without regard to their conflict-of-law provisions. You and
+                  IOG agree to submit to the personal jurisdiction of a federal
+                  or state court located in New York, New York for any actions
+                  for which the dispute resolution provision, as set forth in
+                  Section 8, does not resolve.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Changes.
+                  </Text>{' '}
+                  We reserve the right to change the terms of these Terms,
+                  consistent with applicable law. You agree that your continued
+                  use of the Products after such changes become effective
+                  constitutes your acceptance of the changes. If you do not
+                  agree with any updates to these Terms, you may not continue to
+                  use the Products. Be sure to return to this page periodically
+                  to ensure your familiarity with the most current version of
+                  the Terms of Use. Any changes to the Terms will be effective
+                  on a going forward basis.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Languages.
+                  </Text>{' '}
+                  The English version of these Terms will be the binding version
+                  and all communications, notices, and other actions and
+                  proceedings relating to these Terms will be made and conducted
+                  in English, even if we choose to provide translations of these
+                  Terms into the native languages in certain countries. To the
+                  extent allowed by law, any inconsistencies among the different
+                  translations will be resolved in favor of the English version.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Assignment.
+                  </Text>{' '}
+                  No terms of these Terms, nor any right, obligation, or remedy
+                  hereunder is assignable, transferable, delegable, or
+                  sublicensable by you except with IOG's prior written consent,
+                  and any attempted assignment, transfer, delegation, or
+                  sublicense shall be null and void. IOG may assign, transfer,
+                  or delegate these Terms or any right or obligation or remedy
+                  hereunder in its sole discretion.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Waiver.
+                  </Text>{' '}
+                  Our failure to assert a right or provision under these Terms
+                  will not constitute a waiver of such right or provision.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Headings.
+                  </Text>{' '}
+                  Any heading, caption, or section title contained is inserted
+                  only as a matter of convenience and in no way defines or
+                  explains any section or provision hereof.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Further Assurances.
+                  </Text>{' '}
+                  You agree to execute a hard copy of these Terms and any other
+                  documents, and take any actions at our expense that we may
+                  request to confirm and effect the intent of these Terms and
+                  any of your rights or obligations under these Terms.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Entire Agreement and Severability.
+                  </Text>{' '}
+                  This Agreement supersedes all prior terms, agreements,
+                  discussions and writings regarding the Products and
+                  constitutes the entire agreement between you and us regarding
+                  the Products. If any part of these Terms is found to be
+                  unenforceable, then that part will not affect the
+                  enforceability of the remaining parts of the Agreement, which
+                  will remain in full force and effect.
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Survival.
+                  </Text>{' '}
+                  The following provisions will survive expiration or
+                  termination of these Terms: Section 2 (Your Content), Section
+                  3(c)(Restrictions) and 3(d)(Ownership), Section 6 (Disclaimers
+                  and Limitations of Liability), Section 7 (Indemnification),
+                  Section 8 (Dispute Resolution) and Section 10 (Miscellaneous).
+                </ListItem>
+                <ListItem>
+                  <Text fontWeight="bold" display="inline">
+                    Contact
+                  </Text>{' '}
+                  <Text mb="3">
+                    Feel free to{' '}
+                    <Link
+                      color="teal"
+                      isExternal
+                      textDecoration="underline"
+                      onClick={() => window.open('https://iohk.io/en/contact/')}
+                    >
+                      contact us
+                    </Link>{' '}
+                    with any questions about these Terms. You can also write to
+                    us at:
+                  </Text>
+                  <Text>Input Output Global, Inc.</Text>
+                  <Text>2015 Ionosphere Street, Ste 201</Text>
+                  <Text>Longmont, CO 80504</Text>
+                  <Text>Attn: Legal</Text>
+                </ListItem>
+              </OrderedList>
               <Box h="2" />
             </Box>
           </Scrollbars>

--- a/src/ui/app/components/termsOfUse.jsx
+++ b/src/ui/app/components/termsOfUse.jsx
@@ -66,7 +66,7 @@ const TermsOfUse = React.forwardRef((props, ref) => {
                   "us"
                 </Text>{' '}
                 in this Agreement). These Terms govern your use of this website
-                and all of the related websites, mobile apps, products, and
+                and all of the related websites, mobile apps, products and
                 services offered by IOG and its affiliated entities including
                 our plug-ins and browser extensions (collectively, the{' '}
                 <Text display="inline" fontWeight="bold">
@@ -126,7 +126,7 @@ const TermsOfUse = React.forwardRef((props, ref) => {
                     Additional Terms.
                   </Text>{' '}
                   Specific terms and conditions may apply to specific content,
-                  products, materials, services, or information contained on or
+                  products, materials, services or information contained on or
                   available through various Products or transactions concluded
                   through the Products. Such specific terms may be in addition
                   to these Terms or, where inconsistent with these Terms, only
@@ -146,8 +146,8 @@ const TermsOfUse = React.forwardRef((props, ref) => {
                   >
                     https://iohk.io/en/contact/
                   </Link>
-                  . By submitting feedback in this or any other manner to us,
-                  you grant us the right, at our discretion, to use, disclose,
+                  . By submitting feedback in this or in any other manner to us,
+                  you grant us the right, at our discretion, to use, disclose
                   and otherwise exploit the feedback, in whole or part, without
                   any restriction or compensation to you, as further described
                   in Section 2(b) below.
@@ -202,7 +202,7 @@ const TermsOfUse = React.forwardRef((props, ref) => {
                   <Text fontWeight="bold" display="inline">
                     "IOG Business Purposes"
                   </Text>{' '}
-                  means any use in connection with a Product or IOG co-branded
+                  means any use in connection with a Product or IOG cobranded
                   website, application, publication or service, or any use which
                   advertises, markets or promotes Products, the services or the
                   information within the Products, IOG, or its affiliates. IOG
@@ -256,7 +256,7 @@ const TermsOfUse = React.forwardRef((props, ref) => {
                   will publish any or all of Your Content.
                 </ListItem>
               </OrderedList>
-              <Text fontWeight="bold">3. Our Content and Materials</Text>
+              <Text fontWeight="bold">3. Our Content and Materials.</Text>
               <OrderedList mb="3" pl="2" listStyleType="lower-alpha">
                 <ListItem>
                   <Text fontWeight="bold" display="inline">
@@ -321,7 +321,7 @@ const TermsOfUse = React.forwardRef((props, ref) => {
                   by using or interacting with the Products.
                 </ListItem>
               </OrderedList>
-              <Text fontWeight="bold">4. Other Offerings on the Products</Text>
+              <Text fontWeight="bold">4. Other Offerings on the Products.</Text>
               <OrderedList mb="3" pl="2" listStyleType="lower-alpha">
                 <ListItem>
                   <Text fontWeight="bold" display="inline">
@@ -336,12 +336,12 @@ const TermsOfUse = React.forwardRef((props, ref) => {
                   ). The availability of any Third-Party Services on the
                   Products does not imply our endorsement or verification of the
                   Third-Party Services. We assume no responsibility for, nor do
-                  we endorse or verify the content, offerings, or conduct of
+                  we endorse or verify the content, offerings or conduct of
                   third parties (including but not limited to the products or
                   services offered by third parties or the descriptions of the
                   products or services offered by third parties). We make no
                   warranties or representations with respect to the accuracy,
-                  completeness, or timeliness of any content posted on or in the
+                  completeness or timeliness of any content posted on or in the
                   Products by anyone.
                 </ListItem>
                 <ListItem>
@@ -471,7 +471,7 @@ const TermsOfUse = React.forwardRef((props, ref) => {
                 Products are linked; and/or (d) your negligent or willful
                 misconduct.
               </Text>
-              <Text fontWeight="bold">8 .Dispute Resolution.</Text>
+              <Text fontWeight="bold">8. Dispute Resolution.</Text>
               <Text mb="3">
                 If you have a dispute with IOG, you agree to contact us using
                 the form at{' '}
@@ -625,10 +625,10 @@ const TermsOfUse = React.forwardRef((props, ref) => {
                   Section 8 (Dispute Resolution) and Section 10 (Miscellaneous).
                 </ListItem>
                 <ListItem>
-                  <Text fontWeight="bold" display="inline">
-                    Contact
-                  </Text>{' '}
                   <Text mb="3">
+                    <Text fontWeight="bold" display="inline">
+                      Contact.
+                    </Text>{' '}
                     Feel free to{' '}
                     <Link
                       color="teal"

--- a/src/ui/app/pages/welcome.jsx
+++ b/src/ui/app/pages/welcome.jsx
@@ -106,7 +106,7 @@ const Welcome = () => {
 
 const WalletModal = React.forwardRef((props, ref) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { accept, setAccept } = useAcceptDocs();
+  const { accepted, setAccepted } = useAcceptDocs();
 
   const termsRef = React.useRef();
   const privacyPolicyRef = React.useRef();
@@ -130,7 +130,7 @@ const WalletModal = React.forwardRef((props, ref) => {
             </Text>
             <Box h="4" />
             <Box display="flex" alignItems="center" justifyContent="center">
-              <Checkbox onChange={(e) => setAccept(e.target.checked)} />
+              <Checkbox onChange={(e) => setAccepted(e.target.checked)} />
               <Box w="2" />
               <Text fontWeight={600}>
                 I read and accepted the{' '}
@@ -157,7 +157,7 @@ const WalletModal = React.forwardRef((props, ref) => {
               Close
             </Button>
             <Button
-              isDisabled={!accept}
+              isDisabled={!accepted}
               colorScheme="teal"
               onClick={() => createTab(TAB.createWallet, `?type=generate`)}
             >
@@ -174,8 +174,8 @@ const WalletModal = React.forwardRef((props, ref) => {
 
 const ImportModal = React.forwardRef((props, ref) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { accept, setAccept } = useAcceptDocs();
-  const [select, setSelect] = React.useState(null);
+  const { accepted, setAccepted } = useAcceptDocs();
+  const [selected, setSelected] = React.useState(null);
 
   const termsRef = React.useRef();
   const privacyPolicyRef = React.useRef();
@@ -221,7 +221,7 @@ const ImportModal = React.forwardRef((props, ref) => {
             <Select
               size="sm"
               rounded="md"
-              onChange={(e) => setSelect(e.target.value)}
+              onChange={(e) => setSelected(e.target.value)}
               placeholder="Choose seed phrase length"
             >
               <option value="15">15-word seed phrase</option>
@@ -229,7 +229,7 @@ const ImportModal = React.forwardRef((props, ref) => {
             </Select>
             <Box h="5" />
             <Box display="flex" alignItems="center" justifyContent="center">
-              <Checkbox onChange={(e) => setAccept(e.target.checked)} />
+              <Checkbox onChange={(e) => setAccepted(e.target.checked)} />
               <Box w="2" />
               <Text fontWeight={600}>
                 I read and accepted the{' '}
@@ -256,12 +256,12 @@ const ImportModal = React.forwardRef((props, ref) => {
               Close
             </Button>
             <Button
-              isDisabled={!select || !accept}
+              isDisabled={!selected || !accepted}
               colorScheme="teal"
               onClick={() =>
                 createTab(
                   TAB.createWallet,
-                  `?type=import&length=${parseInt(select)}`
+                  `?type=import&length=${parseInt(selected)}`
                 )
               }
             >

--- a/src/ui/app/pages/welcome.jsx
+++ b/src/ui/app/pages/welcome.jsx
@@ -26,6 +26,7 @@ import { createTab } from '../../../api/extension';
 import { TAB } from '../../../config/config';
 import { useCaptureEvent } from '../../../features/analytics/hooks';
 import { Events } from '../../../features/analytics/events';
+import { useAcceptDocs } from '../../../features/terms-and-privacy/hooks';
 
 const Welcome = () => {
   const capture = useCaptureEvent();
@@ -105,7 +106,7 @@ const Welcome = () => {
 
 const WalletModal = React.forwardRef((props, ref) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [accept, setAccept] = React.useState(false);
+  const { accept, setAccept } = useAcceptDocs();
 
   const termsRef = React.useRef();
   const privacyPolicyRef = React.useRef();
@@ -173,7 +174,7 @@ const WalletModal = React.forwardRef((props, ref) => {
 
 const ImportModal = React.forwardRef((props, ref) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [accept, setAccept] = React.useState(false);
+  const { accept, setAccept } = useAcceptDocs();
   const [select, setSelect] = React.useState(null);
 
   const termsRef = React.useRef();

--- a/src/ui/app/pages/welcome.jsx
+++ b/src/ui/app/pages/welcome.jsx
@@ -193,7 +193,13 @@ const ImportModal = React.forwardRef((props, ref) => {
   }));
   return (
     <>
-      <Modal size="xs" isOpen={isOpen} onClose={onClose} isCentered>
+      <Modal
+        size="xs"
+        isOpen={isOpen}
+        onClose={onClose}
+        isCentered
+        blockScrollOnMount={false}
+      >
         <ModalOverlay />
         <ModalContent>
           <ModalHeader fontSize="md">Import a wallet</ModalHeader>

--- a/src/ui/app/pages/welcome.jsx
+++ b/src/ui/app/pages/welcome.jsx
@@ -118,7 +118,13 @@ const WalletModal = React.forwardRef((props, ref) => {
   }));
   return (
     <>
-      <Modal size="xs" isOpen={isOpen} onClose={onClose} isCentered>
+      <Modal
+        size="xs"
+        isOpen={isOpen}
+        onClose={onClose}
+        isCentered
+        blockScrollOnMount={false}
+      >
         <ModalOverlay />
         <ModalContent>
           <ModalHeader fontSize="md">Create a wallet</ModalHeader>

--- a/src/ui/indexMain.jsx
+++ b/src/ui/indexMain.jsx
@@ -25,6 +25,7 @@ import { useStoreActions, useStoreState } from 'easy-peasy';
 import { AnalyticsProvider } from '../features/analytics/provider';
 import { EventTracker } from '../features/analytics/event-tracker';
 import { ExtensionViews } from '../features/analytics/types';
+import { TermsAndPrivacyProvider } from '../features/terms-and-privacy';
 
 const App = () => {
   const route = useStoreState((state) => state.globalModel.routeStore.route);
@@ -79,7 +80,14 @@ const App = () => {
   ) : (
     <div style={{ overflowX: 'hidden' }}>
       <Routes>
-        <Route path="*" element={<Wallet />} />
+        <Route
+          path="*"
+          element={
+            <TermsAndPrivacyProvider>
+              <Wallet />
+            </TermsAndPrivacyProvider>
+          }
+        />
         <Route path="/welcome" element={<Welcome />} />
         <Route path="/settings/*" element={<Settings />} />
         <Route path="/send" element={<Send />} />


### PR DESCRIPTION
### Description
- Updated terms and conditions and privacy policy.
- Added "terms and policy update" prompt to be displayed for existing installations. 

### Testing
- If installing nami for the first time, the new terms and policy is displayed as usual in the create/import modal, analytics consent and about screen.
- If wallet is already created, the update modal should be displayed with acceptance prompt
- To retest after accepting, call `chrome.storage.local.remove('acceptedLegalDocsVersion')`


### Screenshot
<img width="401" alt="image" src="https://github.com/input-output-hk/nami/assets/11845759/a05b243e-a076-4880-b1ee-3dfe857dd4ee">


