### PR TITLE
Fix - show correct assetID in assets and NFT´s

### DIFF
--- a/src/ui/app/components/asset.jsx
+++ b/src/ui/app/components/asset.jsx
@@ -37,6 +37,12 @@ const Asset = ({ asset, enableSend, ...props }) => {
   const settings = useStoreState((state) => state.settings.settings);
 
   const fetchMetadata = async () => {
+    let detailedConstructedAsset;
+
+    if (asset.unit !== 'lovelace') {
+      detailedConstructedAsset = await getAsset(asset.unit);
+    }
+
     const detailedAsset =
       asset.unit === 'lovelace'
         ? {
@@ -45,9 +51,11 @@ const Asset = ({ asset, enableSend, ...props }) => {
             decimals: 6,
           }
         : {
-            ...(await getAsset(asset.unit)),
+            ...detailedConstructedAsset,
             quantity: asset.quantity,
             input: asset.input,
+            fingerprint:
+              asset.fingerprint ?? detailedConstructedAsset.fingerprint,
           };
     if (!isMounted.current) return;
     setToken(detailedAsset);

--- a/src/ui/app/components/collectible.jsx
+++ b/src/ui/app/components/collectible.jsx
@@ -28,9 +28,11 @@ const Collectible = React.forwardRef(({ asset }, ref) => {
   const [showInfo, setShowInfo] = React.useState(false);
 
   const fetchMetadata = async () => {
+    const detailedConstructedAsset = await getAsset(asset.unit);
     const detailedAsset = {
-      ...(await getAsset(asset.unit)),
+      ...detailedConstructedAsset,
       quantity: asset.quantity,
+      fingerprint: asset.fingerprint ?? detailedConstructedAsset.fingerprint,
     };
     if (!isMounted.current) return;
     setToken(detailedAsset);

--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -184,7 +184,7 @@ const Wallet = () => {
     currentAccount.assets.forEach((asset) => {
       asset.policy = asset.unit.slice(0, 56);
       asset.name = Buffer.from(asset.unit.slice(56), 'hex');
-      asset.fingerprint = new AssetFingerprint(
+      asset.fingerprint = AssetFingerprint.fromParts(
         Buffer.from(asset.policy, 'hex'),
         asset.name
       ).fingerprint();


### PR DESCRIPTION
The assetFingerprint function was outdated and it was not passing the props right to the component. 

AssetID: asset1825hfzlnn8fx7yw4we2wny9qv2dkflwf2h8p80 
Cexplorer: https://preprod.cexplorer.io/asset/asset1825hfzlnn8fx7yw4we2wny9qv2dkflwf2h8p80
<img width="368" alt="Screenshot 2024-01-26 at 12 17 18" src="https://github.com/input-output-hk/nami/assets/4052063/5d2a2955-ea63-4e40-8375-333a199e8917">

AssetID: asset1sjk0uucljv4qxxnhq8gjy7r5mar64erhfuh4q8
https://preprod.cexplorer.io/asset/asset1sjk0uucljv4qxxnhq8gjy7r5mar64erhfuh4q8
<img width="381" alt="Screenshot 2024-01-26 at 12 18 14" src="https://github.com/input-output-hk/nami/assets/4052063/eb3d0923-7f51-425e-8be8-cd79032de3c8">
