### PR TITLE
FIX: update delegate button color to be readable

### DIFF
--- a/src/ui/app/pages/wallet.jsx
+++ b/src/ui/app/pages/wallet.jsx
@@ -283,7 +283,7 @@ const Wallet = () => {
                     }}
                     variant="solid"
                     size="xs"
-                    colorScheme="whiteAlpha"
+                    color="whiteAlpha"
                     rounded="lg"
                   >
                     Delegate


### PR DESCRIPTION
It updates the color of the button to be readable in dark UI without changing the light UI. 
![Screenshot 2024-01-26 at 13 53 00](https://github.com/input-output-hk/nami/assets/4052063/da490473-e589-4335-906d-e2797bb47617)
![Screenshot 2024-01-26 at 13 51 20](https://github.com/input-output-hk/nami/assets/4052063/9c33eafb-af41-4dad-8df8-1fa3a967be08)
![Screenshot 2024-01-26 at 13 50 58](https://github.com/input-output-hk/nami/assets/4052063/c35325b6-913e-447a-9726-48bb75d64b3e)
