### PR TITLE
[LW-9665] add correct assetId in send screen and search for assets

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1727,7 +1727,7 @@ export const getAsset = async (unit) => {
     const bufferName = Buffer.from(name, 'hex');
     asset.unit = unit;
     asset.policy = policyId;
-    asset.fingerprint = new AssetFingerprint(
+    asset.fingerprint = AssetFingerprint.fromParts(
       Buffer.from(policyId, 'hex'),
       bufferName
     ).fingerprint();

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -310,7 +310,7 @@ export const valueToAssets = async (value) => {
           Buffer.from(policyAsset.name(), 'hex').toString('hex');
         const _policy = asset.slice(0, 56);
         const _name = asset.slice(56);
-        const fingerprint = new AssetFingerprint(
+        const fingerprint = AssetFingerprint.fromParts(
           Buffer.from(_policy, 'hex'),
           Buffer.from(_name, 'hex')
         ).fingerprint();


### PR DESCRIPTION
Summary: 
The incorrect AssetID was shown in the Send screen and the incorrect one was used to filter the asset in the search input, currently we are displaying the correct AssetId as well as we are able to perform the search with the correct ID . 