### PR TITLE
ci: replace committed build.zip with Workflow artefact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,13 @@ jobs:
         run: npm ci
       - name: Test
         run: npm test
+      - name: Generates Secrets File
+        run: |
+          echo "export default { PROJECT_ID_MAINNET: '${{ secrets.PROJECT_ID_MAINNET  }}', PROJECT_ID_PREVIEW: '${{ secrets.PROJECT_ID_PREVIEW  }}', PROJECT_ID_PREPROD: '${{ secrets.PROJECT_ID_PREPROD  }}'};" > secrets.production.js
+      - name: Build
+        run: npm run build
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Nami is a browser based wallet extension to interact with the Cardano blockchain
 
 ### Testnet
 
-[Download testnet version](./build.zip)
-
-Extract the zip. Then go to `chrome://extensions`, click Load unpacked at the top left and select the build folder.
+Download and extract the zip attached to the latest [Release](https://github.com/input-output-hk/nami/releases). Then go to `chrome://extensions`, click Load unpacked at the top left and select the build folder.
 
 ### Injected API
 


### PR DESCRIPTION
This is a corrective action identified during the recent post incident report. The build is now performed as part of the CI workflow, in a more controlled environment, using API keys stored as GitHub repository secrets. See attached workflow run

![image](https://github.com/input-output-hk/nami/assets/303881/70678c57-f2b2-4246-9148-0626c704baf6)


We'll create a GitHub release next time, so until then the "testnet" README instructions lead to an empty page. Users can access the test networks via the Chrome store version and the prior committed build can be found on earlier revision if needed sooner. 

### Testing
- Download the build from the CI run and run a few smoke tests.
- Verify the API requests are landing in the Nami account by coordinating with me to check the Blockfrost admin panel.