### PR TITLE
Add legal section to settings LW-9716

### DIFF
--- a/src/features/analytics/ui/AnalyticsConsentModal.jsx
+++ b/src/features/analytics/ui/AnalyticsConsentModal.jsx
@@ -26,7 +26,7 @@ export const AnalyticsConsentModal = ({ askForConsent, setConsent }) => {
       >
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader fontSize="md">Legal & analytics</ModalHeader>
+          <ModalHeader fontSize="md">Legal & Analytics</ModalHeader>
           <ModalBody>
             <Text
               mb="1"
@@ -34,12 +34,22 @@ export const AnalyticsConsentModal = ({ askForConsent, setConsent }) => {
               fontWeight="bold"
               id="terms-of-service-agreement"
             >
-              Give us a hand to improve your experience
+              Give us a hand to improve your Nami experience
             </Text>
             <Text fontSize="sm">
-              By sharing analytics data from your browser, you can help us
-              improve the quality and performance of Nami. For more information
-              on our privacy practices, please see our&nbsp;
+              We would like to collect anonymous information from your browser
+              extension to help us improve the quality and performance of Nami.
+              This may include data about how you use our service, your
+              preferences and information about your system. You can always
+              opt-out (see the&nbsp;
+              <Link
+                onClick={() => window.open('https://www.namiwallet.io/')}
+                textDecoration="underline"
+              >
+                FAQ
+              </Link>
+              &nbsp;for more details). For more information on our privacy
+              practices, see our&nbsp;
               <Link
                 onClick={() => privacyPolRef.current.openModal()}
                 textDecoration="underline"
@@ -51,10 +61,10 @@ export const AnalyticsConsentModal = ({ askForConsent, setConsent }) => {
           </ModalBody>
           <ModalFooter>
             <Button mr={3} variant="ghost" onClick={() => setConsent(false)}>
-              Decline
+              No thanks
             </Button>
             <Button colorScheme="teal" onClick={() => setConsent(true)}>
-              Accept
+              I agree
             </Button>
           </ModalFooter>
         </ModalContent>

--- a/src/features/analytics/ui/AnalyticsConsentModal.jsx
+++ b/src/features/analytics/ui/AnalyticsConsentModal.jsx
@@ -27,7 +27,6 @@ export const AnalyticsConsentModal = ({ askForConsent, setConsent }) => {
         <ModalOverlay />
         <ModalContent>
           <ModalHeader fontSize="md">Legal & analytics</ModalHeader>
-          <ModalCloseButton />
           <ModalBody>
             <Text
               mb="1"

--- a/src/features/analytics/ui/AnalyticsConsentModal.jsx
+++ b/src/features/analytics/ui/AnalyticsConsentModal.jsx
@@ -23,6 +23,7 @@ export const AnalyticsConsentModal = ({ askForConsent, setConsent }) => {
         isCentered
         onClose={() => setConsent(false)}
         blockScrollOnMount={false}
+        closeOnOverlayClick={false}
       >
         <ModalOverlay />
         <ModalContent>

--- a/src/features/settings/legal/LegalSettings.tsx
+++ b/src/features/settings/legal/LegalSettings.tsx
@@ -8,13 +8,13 @@ import {
   Tooltip,
 } from '@chakra-ui/react';
 import React, { useRef } from 'react';
-import { useAnalyticsConsent } from '../../analytics/hooks';
 import { ChevronRightIcon, InfoOutlineIcon } from '@chakra-ui/icons';
 import PrivacyPolicy from '../../../ui/app/components/privacyPolicy';
 import TermsOfUse from '../../../ui/app/components/termsOfUse';
+import { useAnalyticsContext } from '../../analytics/provider';
 
 export const LegalSettings = () => {
-  const [analyticsConsent, setAnalyticsConsent] = useAnalyticsConsent();
+  const [analytics, setAnalyticsConsent] = useAnalyticsContext();
   const termsRef = useRef<{ openModal: () => void }>();
   const privacyPolicyRef = useRef<{ openModal: () => void }>();
   return (
@@ -50,8 +50,8 @@ export const LegalSettings = () => {
         </Text>
         <Spacer />
         <Switch
-          isChecked={analyticsConsent}
-          onChange={() => setAnalyticsConsent(!analyticsConsent)}
+          isChecked={analytics.consent}
+          onChange={() => setAnalyticsConsent(!analytics.consent)}
         />
       </Flex>
       <Box height="3" />

--- a/src/features/settings/legal/LegalSettings.tsx
+++ b/src/features/settings/legal/LegalSettings.tsx
@@ -1,0 +1,81 @@
+import {
+  Box,
+  Button,
+  Flex,
+  Spacer,
+  Switch,
+  Text,
+  Tooltip,
+} from '@chakra-ui/react';
+import React, { useRef } from 'react';
+import { useAnalyticsConsent } from '../../analytics/hooks';
+import { ChevronRightIcon, InfoOutlineIcon } from '@chakra-ui/icons';
+import PrivacyPolicy from '../../../ui/app/components/privacyPolicy';
+import TermsOfUse from '../../../ui/app/components/termsOfUse';
+
+export const LegalSettings = () => {
+  const [analyticsConsent, setAnalyticsConsent] = useAnalyticsConsent();
+  const termsRef = useRef<{ openModal: () => void }>();
+  const privacyPolicyRef = useRef<{ openModal: () => void }>();
+  return (
+    <>
+      <Box height="10" />
+      <Text fontSize="lg" fontWeight="bold">
+        Legal
+      </Text>
+      <Box height="6" />
+      <Flex minWidth="65%" padding="0 16px" alignItems="center" gap="2">
+        <Text fontSize="16" fontWeight="bold">
+          Analytics
+          <Tooltip
+            label={
+              <Box padding="1">
+                We'll collect anonymous analytics info from your browser
+                extension to help us improve the quality and performance of Nami
+              </Box>
+            }
+            fontSize="sm"
+            hasArrow
+            placement="auto"
+          >
+            <InfoOutlineIcon
+              cursor="help"
+              color="#4A5568"
+              ml="10px"
+              width="14px"
+              height="14px"
+              display="inline-block"
+            />
+          </Tooltip>
+        </Text>
+        <Spacer />
+        <Switch
+          isChecked={analyticsConsent}
+          onChange={() => setAnalyticsConsent(!analyticsConsent)}
+        />
+      </Flex>
+      <Box height="3" />
+      <Button
+        justifyContent="space-between"
+        width="65%"
+        rightIcon={<ChevronRightIcon />}
+        variant="ghost"
+        onClick={() => termsRef.current?.openModal()}
+      >
+        Terms of Use
+      </Button>
+      <Box height="1" />
+      <Button
+        justifyContent="space-between"
+        width="65%"
+        rightIcon={<ChevronRightIcon />}
+        variant="ghost"
+        onClick={() => privacyPolicyRef.current?.openModal()}
+      >
+        Privacy Policy
+      </Button>
+      <PrivacyPolicy ref={privacyPolicyRef} />
+      <TermsOfUse ref={termsRef} />
+    </>
+  );
+};

--- a/src/features/settings/legal/LegalSettings.tsx
+++ b/src/features/settings/legal/LegalSettings.tsx
@@ -2,6 +2,12 @@ import {
   Box,
   Button,
   Flex,
+  Link,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
   Spacer,
   Switch,
   Text,
@@ -27,26 +33,36 @@ export const LegalSettings = () => {
       <Flex minWidth="65%" padding="0 16px" alignItems="center" gap="2">
         <Text fontSize="16" fontWeight="bold">
           Analytics
-          <Tooltip
-            label={
-              <Box padding="1">
-                We'll collect anonymous analytics info from your browser
-                extension to help us improve the quality and performance of Nami
-              </Box>
-            }
-            fontSize="sm"
-            hasArrow
-            placement="auto"
-          >
-            <InfoOutlineIcon
-              cursor="help"
-              color="#4A5568"
-              ml="10px"
-              width="14px"
-              height="14px"
-              display="inline-block"
-            />
-          </Tooltip>
+          <Popover autoFocus={false}>
+            <PopoverTrigger>
+              <InfoOutlineIcon
+                cursor="pointer"
+                color="#4A5568"
+                ml="10px"
+                width="14px"
+                height="14px"
+                display="inline-block"
+              />
+            </PopoverTrigger>
+            <PopoverContent>
+              <PopoverArrow />
+              <PopoverBody>
+                <Text
+                  color="grey"
+                  fontWeight="500"
+                  fontSize="14"
+                  lineHeight="24px"
+                >
+                  We'll collect anonymous analytics info from your browser
+                  extension to help us improve the quality and performance
+                  of&nbsp;
+                  <Link onClick={() => window.open('https://namiwallet.io')}>
+                    Nami
+                  </Link>
+                </Text>
+              </PopoverBody>
+            </PopoverContent>
+          </Popover>
         </Text>
         <Spacer />
         <Switch

--- a/src/features/settings/legal/LegalSettings.tsx
+++ b/src/features/settings/legal/LegalSettings.tsx
@@ -53,12 +53,17 @@ export const LegalSettings = () => {
                   fontSize="14"
                   lineHeight="24px"
                 >
-                  We'll collect anonymous analytics info from your browser
-                  extension to help us improve the quality and performance
-                  of&nbsp;
-                  <Link onClick={() => window.open('https://namiwallet.io')}>
-                    Nami
+                  We collect anonymous information from your browser extension
+                  to help us improve the quality and performance of Nami. This
+                  may include data about how you use our service, your
+                  preferences and information about your system. Read more&nbsp;
+                  <Link
+                    onClick={() => window.open('https://namiwallet.io')}
+                    textDecoration="underline"
+                  >
+                    here
                   </Link>
+                  .
                 </Text>
               </PopoverBody>
             </PopoverContent>

--- a/src/ui/app/pages/settings.jsx
+++ b/src/ui/app/pages/settings.jsx
@@ -46,6 +46,7 @@ import AvatarLoader from '../components/avatarLoader';
 import { ChangePasswordModal } from '../components/changePasswordModal';
 import { useCaptureEvent } from '../../../features/analytics/hooks';
 import { Events } from '../../../features/analytics/events';
+import { LegalSettings } from '../../../features/settings/legal/LegalSettings';
 
 const Settings = () => {
   const navigate = useNavigate();
@@ -77,6 +78,7 @@ const Settings = () => {
           />
           <Route path="whitelisted" element={<Whitelisted />} />
           <Route path="network" element={<Network />} />
+          <Route path="legal" element={<LegalSettings />} />
         </Routes>
       </Box>
     </>
@@ -129,6 +131,18 @@ const Overview = () => {
         }}
       >
         Network
+      </Button>
+      <Box height="1" />
+      <Button
+        justifyContent="space-between"
+        width="65%"
+        rightIcon={<ChevronRightIcon />}
+        variant="ghost"
+        onClick={() => {
+          navigate('legal');
+        }}
+      >
+        Legal
       </Button>
     </>
   );

--- a/src/ui/indexMain.jsx
+++ b/src/ui/indexMain.jsx
@@ -12,7 +12,6 @@ import {
 } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import { POPUP } from '../config/config';
-import { useAnalyticsConsent } from '../features/analytics/hooks';
 import { AnalyticsConsentModal } from '../features/analytics/ui/AnalyticsConsentModal';
 import Main from './index';
 import { Box, Spinner } from '@chakra-ui/react';
@@ -22,7 +21,10 @@ import { getAccounts } from '../api/extension';
 import Settings from './app/pages/settings';
 import Send from './app/pages/send';
 import { useStoreActions, useStoreState } from 'easy-peasy';
-import { AnalyticsProvider } from '../features/analytics/provider';
+import {
+  AnalyticsProvider,
+  useAnalyticsContext,
+} from '../features/analytics/provider';
 import { EventTracker } from '../features/analytics/event-tracker';
 import { ExtensionViews } from '../features/analytics/types';
 import { TermsAndPrivacyProvider } from '../features/terms-and-privacy';
@@ -35,7 +37,7 @@ const App = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [isLoading, setIsLoading] = React.useState(true);
-  const [analyticsConsent, setAnalyticsConsent] = useAnalyticsConsent();
+  const [analytics, setAnalyticsConsent] = useAnalyticsContext();
   const init = async () => {
     const hasWallet = await getAccounts();
     if (hasWallet) {
@@ -93,7 +95,7 @@ const App = () => {
         <Route path="/send" element={<Send />} />
       </Routes>
       <AnalyticsConsentModal
-        askForConsent={analyticsConsent === undefined}
+        askForConsent={analytics.consent === undefined}
         setConsent={setAnalyticsConsent}
       />
     </div>


### PR DESCRIPTION
This PR adds a legal section to the settings screen where analytics can be toggled on/off and Terms of Use + Privacy Policy can be opened. Also other analytics related copy was updated:

<img width="398" alt="Bildschirmfoto 2024-02-15 um 17 27 57" src="https://github.com/input-output-hk/nami/assets/172414/db3756fa-dca9-4359-b5e4-4387e4b3cb3d">

<img width="400" alt="Bildschirmfoto 2024-02-15 um 17 31 58" src="https://github.com/input-output-hk/nami/assets/172414/4638264f-0797-4522-8cb9-24039658fce4">


<img width="399" alt="Bildschirmfoto 2024-02-15 um 17 29 29" src="https://github.com/input-output-hk/nami/assets/172414/f0621597-5eff-46b7-bd95-7441be58985f">

