### PR TITLE
fix(NFT Images): Support array image types for CIP-68

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1758,7 +1758,7 @@ export const getAsset = async (unit) => {
         const metadata = metadataDatum && Data.toJson(metadataDatum.fields[0]);
 
         asset.displayName = metadata.name;
-        asset.image = metadata.image ? linkToSrc(metadata.image) : '';
+        asset.image = metadata.image ? linkToSrc(convertMetadataPropToString(metadata.image)) : '';
         asset.decimals = 0;
       } catch (_e) {
         asset.displayName = asset.name;
@@ -1785,7 +1785,7 @@ export const getAsset = async (unit) => {
         const metadata = metadataDatum && Data.toJson(metadataDatum.fields[0]);
 
         asset.displayName = metadata.name;
-        asset.image = linkToSrc(metadata.logo) || '';
+        asset.image = linkToSrc(convertMetadataPropToString(metadata.logo)) || '';
         asset.decimals = metadata.decimals || 0;
       } catch (_e) {
         asset.displayName = asset.name;


### PR DESCRIPTION
Per the recommendation of the pool.pm team and in compliance with metadata standards, we sometimes see NFT IPFS links represented as arrays of strings.  These arrays are meant to be concatenated directly to produce the IPFS link (or data scheme, etc.).

Because the image is retrieved in the send assets page, without this change users are UNABLE to send assets in CIP-68 format (since the decimals do not get properly set in `nami/src/api/extension/index.js#1762`).

[ Testing: npm test, manually built and submitted tx from Nami ]
[ Test Artifacts: txn 5e342b856efa596da433e3eec4256809cfe9bd9c4c9c39eb316328080ced13f1 ]