### PR TITLE
fix: timeout http requests to Milkomeda backend

### DIFF
--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -1584,16 +1584,22 @@ export const getAdaHandle = async (assetName) => {
  */
 export const getMilkomedaData = async (ethAddress) => {
   const network = await getNetwork();
+  const isAddressAllowedController = new AbortController();
+  const stargateController = new AbortController();
+  setTimeout(() => isAddressAllowedController.abort(), 500);
   if (network.id === NETWORK_ID.mainnet) {
     const { isAllowed } = await fetch(
       'https://' +
         milkomedaNetworks['c1-mainnet'].backendEndpoint +
-        `/v1/isAddressAllowed?address=${ethAddress}`
+        `/v1/isAddressAllowed?address=${ethAddress}`,
+        { signal: isAddressAllowedController.signal }
     ).then((res) => res.json());
+    setTimeout(() => stargateController.abort(), 500);
     const { ada, ttl_expiry, assets, current_address } = await fetch(
       'https://' +
         milkomedaNetworks['c1-mainnet'].backendEndpoint +
-        '/v1/stargate'
+        '/v1/stargate',
+        { signal: stargateController.signal }
     ).then((res) => res.json());
     const protocolMagic = milkomedaNetworks['c1-mainnet'].protocolMagic;
     return {
@@ -1608,12 +1614,15 @@ export const getMilkomedaData = async (ethAddress) => {
     const { isAllowed } = await fetch(
       'https://' +
         milkomedaNetworks['c1-devnet'].backendEndpoint +
-        `/v1/isAddressAllowed?address=${ethAddress}`
+        `/v1/isAddressAllowed?address=${ethAddress}`,
+        { signal: isAddressAllowedController.signal }
     ).then((res) => res.json());
+    setTimeout(() => stargateController.abort(), 500);
     const { ada, ttl_expiry, assets, current_address } = await fetch(
       'https://' +
         milkomedaNetworks['c1-devnet'].backendEndpoint +
-        '/v1/stargate'
+        '/v1/stargate',
+        { signal: stargateController.signal }
     ).then((res) => res.json());
     const protocolMagic = milkomedaNetworks['c1-devnet'].protocolMagic;
     return {


### PR DESCRIPTION
### Context
Nami has an integration with [Milkomeda](https://milkomeda.com/), a Cardano EVM sidechain, that involves making at least two HTTP requests to external service, run by Flint Wallet, in the send form on each load. If this service is not responding, sending funds is blocked, even for users not intending to use the sidechain. The current application design is not resilient to this outage, disabling form fields until a response is received. https://github.com/input-output-hk/nami/pull/880 improved error handling, but to handle hanging requests, a client side timeout is required.

### Solution
Abort the HTTP requests after 500ms, which should be sufficient time to receive a response without impacting UX.

#### Screencasts
[Server timing out](https://github.com/input-output-hk/nami/assets/303881/d254ae64-28bb-4e18-9f98-bd03b6e0890a)
[Requests received](https://github.com/input-output-hk/nami/assets/303881/bbe234d8-fffa-4955-a506-8fee342fa6ce)


