### PR TITLE
fix: collateral check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nami-wallet",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nami-wallet",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nami-wallet",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Maintained by IOG",
   "license": "Apache-2.0",
   "repository": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Nami",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Maintained by IOG",
   "background": { "service_worker": "background.bundle.js" },
   "action": {

--- a/src/ui/app/pages/signTx.jsx
+++ b/src/ui/app/pages/signTx.jsx
@@ -478,7 +478,9 @@ const SignTx = ({ request, controller }) => {
           ) {
             return;
           }
-
+          const collateralReturn = tx.body().collateral_return();
+          // presence of collateral return means "account" collateral can be ignored
+          if (collateralReturn) return;
           if (!account.collateral) {
             setIsLoading((l) => ({ ...l, error: 'Collateral not set' }));
             return;


### PR DESCRIPTION
## Context
The collateral validation logic, in the sign transaction component, is unreasonably expecting explicit collateral to **always** be set **if** there are no UTxOs that have less than 50 Ada. This means if a DApp uses CIP-40 collateral return, and has no suitable UTxOs, an error will be thrown.

## Solution
If collateral return is found in the transaction body, return from the function to avoid the checks against "account collateral" presence and equality with collateral input.