### PR TITLE
fix: replace CML with Blaze for input selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "nami-wallet",
-  "version": "3.8.1",
+  "version": "3.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nami-wallet",
-      "version": "3.8.1",
+      "version": "3.8.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "@blaze-cardano/sdk": "^0.1.32",
         "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.3",
         "@cardano-sdk/core": "^0.39.2",
         "@chakra-ui/css-reset": "^2.3.0",
@@ -2117,6 +2118,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -2137,6 +2143,195 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@blaze-cardano/core": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/core/-/core-0.4.5.tgz",
+      "integrity": "sha512-2JGV/DhAH8x/lXboPIpD7//OLhIYSMCzRmFeQvwefjB/p214h3TpFGonc0dvna7epTgu3sz/Qas0ycz6bSEdfA==",
+      "dependencies": {
+        "@cardano-sdk/core": "^0.35.4",
+        "@cardano-sdk/crypto": "^0.1.28",
+        "@cardano-sdk/util": "^0.15.4",
+        "@noble/curves": "^1.4.2",
+        "@noble/ed25519": "^2.1.0",
+        "@noble/hashes": "^1.4.0",
+        "@scure/bip39": "^1.3.0",
+        "blakejs": "^1.2.1"
+      }
+    },
+    "node_modules/@blaze-cardano/core/node_modules/@cardano-ogmios/client": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@cardano-ogmios/client/-/client-6.3.0.tgz",
+      "integrity": "sha512-nWaZ76n/R+p8nxBfRCetOuoDH8o5QToL5zWhRUu9EwHDJqM/0rzvYEk9JYCikAcVlC1qt6+3CcG4nCpG0dsptw==",
+      "dependencies": {
+        "@cardano-ogmios/schema": "6.3.0",
+        "@cardanosolutions/json-bigint": "^1.0.1",
+        "@types/json-bigint": "^1.0.1",
+        "bech32": "^2.0.0",
+        "cross-fetch": "^3.1.4",
+        "fastq": "^1.11.0",
+        "isomorphic-ws": "^4.0.1",
+        "nanoid": "^3.1.31",
+        "ts-custom-error": "^3.2.0",
+        "ws": "^7.4.6"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@blaze-cardano/core/node_modules/@cardano-ogmios/schema": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@cardano-ogmios/schema/-/schema-6.3.0.tgz",
+      "integrity": "sha512-reM7NDYV4cgMAdFCzypoIuCVgSUfR9ztRMlk6p7k0cTeqUkbMfA83ps1FVkTDxzXxFjgM4EkhqoJyRjKIKRPQA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@blaze-cardano/core/node_modules/@cardano-sdk/core": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.35.4.tgz",
+      "integrity": "sha512-FgNHOs9/kp8mqNagWkghn+Xfj0Wfr7HhBhxW92RZL2kKop7zyWlwhhXIZMdZvbHzqnAWhdIg2IYNb8j6IMI3yA==",
+      "dependencies": {
+        "@cardano-ogmios/client": "6.3.0",
+        "@cardano-ogmios/schema": "6.3.0",
+        "@cardano-sdk/crypto": "~0.1.28",
+        "@cardano-sdk/util": "~0.15.4",
+        "@cardano-sdk/util-dev": "~0.21.8",
+        "@foxglove/crc": "^0.0.3",
+        "@scure/base": "^1.1.1",
+        "fraction.js": "4.0.1",
+        "ip-address": "^9.0.5",
+        "lodash": "^4.17.21",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.4.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@blaze-cardano/core/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "node_modules/@blaze-cardano/core/node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/@blaze-cardano/core/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@blaze-cardano/jest-config": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/jest-config/-/jest-config-0.0.1.tgz",
+      "integrity": "sha512-q/0BzXoN+PP4kcwmqthJEYrQ1ee3pZ1Y2dV7X7levyccX8yVMxgMUvJjXhZKl0Bb9g8JidoxanVaBW0d0Y0mSw=="
+    },
+    "node_modules/@blaze-cardano/ogmios": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/ogmios/-/ogmios-0.0.5.tgz",
+      "integrity": "sha512-mWMiXD3hTYm+uxnANMLf5JfvJpqmNtJ05YW3YFLtYx32pMnXBjUToBfZ9N97OazjLjt1Hwd09jUn6HyAo81fnA==",
+      "dependencies": {
+        "@cardano-ogmios/schema": "^6.4.0",
+        "isomorphic-ws": "^5.0.0"
+      }
+    },
+    "node_modules/@blaze-cardano/ogmios/node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/@blaze-cardano/query": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/query/-/query-0.2.16.tgz",
+      "integrity": "sha512-+C9h2f97Vb1q5o071yH+Ej1SypuGD5gOS7yGoyKvnh3gjnj/+s45A5iLrGg2u7X0cG5MiRtIcWdPV5juovzi/A==",
+      "dependencies": {
+        "@blaze-cardano/core": "0.4.5",
+        "@blaze-cardano/jest-config": "0.0.1",
+        "@blaze-cardano/ogmios": "0.0.5",
+        "@cardano-ogmios/schema": "^6.6.1",
+        "ws": "^8.17.1"
+      }
+    },
+    "node_modules/@blaze-cardano/query/node_modules/@cardano-ogmios/schema": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@cardano-ogmios/schema/-/schema-6.6.1.tgz",
+      "integrity": "sha512-xyTPpD5g20U44kVnU8QAil77/OOOZvU/AveUSmEjXJmDtZV/+4/pufshkfk7Dwui1P3wg12+vHMw+UjRciuX4g==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@blaze-cardano/sdk": {
+      "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/sdk/-/sdk-0.1.32.tgz",
+      "integrity": "sha512-3xVj/P9IeoXgJt8Vk8ofdanjTWqYQBjR4Z1N/MGL41bvoLOxlNgfAz/Nn7Iy0qEEy798/VysffC2YTZsKG2U2A==",
+      "dependencies": {
+        "@blaze-cardano/core": "0.4.5",
+        "@blaze-cardano/query": "0.2.16",
+        "@blaze-cardano/tx": "0.5.15",
+        "@blaze-cardano/uplc": "0.1.26",
+        "@blaze-cardano/wallet": "0.1.51"
+      }
+    },
+    "node_modules/@blaze-cardano/tx": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/tx/-/tx-0.5.15.tgz",
+      "integrity": "sha512-4LxN2LxxnQIjJ1EtcbjPHI0ZabYTP7SjaCJFxOu6guTmdxqlk3kK7yH0e+H67F5F+4zlYhOkIzRbIlb5zEFpqg==",
+      "dependencies": {
+        "@blaze-cardano/core": "0.4.5"
+      }
+    },
+    "node_modules/@blaze-cardano/uplc": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/uplc/-/uplc-0.1.26.tgz",
+      "integrity": "sha512-lj93czmI8fgU6tnomlKqWt0xw6PsXldcdidvZpkWRLbmoKppT6WXxVsPiMDJGY1fIPVBkrUceTCSWyMdFQUk/A==",
+      "dependencies": {
+        "@blaze-cardano/core": "0.4.5",
+        "@blaze-cardano/tx": "0.5.15",
+        "hex-encoding": "^2.0.2"
+      }
+    },
+    "node_modules/@blaze-cardano/wallet": {
+      "version": "0.1.51",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/wallet/-/wallet-0.1.51.tgz",
+      "integrity": "sha512-AO7BdsWki78S3fG5rAczVE8xLbK0DdKGCstexVP56xBaplwpkKF724UchCbK/LNCyv4+g1/7jcay/DQzNsIg2w==",
+      "dependencies": {
+        "@blaze-cardano/core": "0.4.5",
+        "@blaze-cardano/query": "0.2.16",
+        "@blaze-cardano/tx": "0.5.15"
       }
     },
     "node_modules/@cardano-foundation/ledgerjs-hw-app-cardano": {
@@ -2300,6 +2495,197 @@
       "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
       "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
     },
+    "node_modules/@cardano-sdk/dapp-connector": {
+      "version": "0.12.35",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/dapp-connector/-/dapp-connector-0.12.35.tgz",
+      "integrity": "sha512-0X+mibT6tsJF40htsVYz2PsnX7YQkqQQEnwGR0J7IeVf2EooEFdWXzguVLoukdgpeIdkbTGAuAmVnTLrJSzjEw==",
+      "dependencies": {
+        "@cardano-sdk/core": "~0.39.2",
+        "@cardano-sdk/crypto": "~0.1.30",
+        "@cardano-sdk/util": "~0.15.5",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4",
+        "webextension-polyfill": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardano-sdk/key-management": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/key-management/-/key-management-0.21.2.tgz",
+      "integrity": "sha512-+VpJsww8P0ggX7zfJr5GLrD6qtAr6sYlTfeIe+cdnYUX9EfFdFusx3Q99cYFrSbhXhyjnImZfW+z8N3A9yBb5w==",
+      "dependencies": {
+        "@cardano-sdk/core": "~0.36.0",
+        "@cardano-sdk/crypto": "~0.1.29",
+        "@cardano-sdk/dapp-connector": "~0.12.27",
+        "@cardano-sdk/util": "~0.15.4",
+        "@emurgo/cardano-message-signing-nodejs": "^1.0.1",
+        "bip39": "^3.0.4",
+        "chacha": "^2.1.0",
+        "get-random-values": "^2.0.0",
+        "lodash": "^4.17.21",
+        "pbkdf2": "^3.1.2",
+        "rxjs": "^7.4.0",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardano-sdk/key-management/node_modules/@cardano-sdk/core": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.36.0.tgz",
+      "integrity": "sha512-FRveIH7U+fBEqrw+eITW3ocqh7CBMbgUcnVjhxaIA0ZlAxasQj9mu+jkYMkB2vcO8JaG5BAp7S8wVlEsLMoQ0w==",
+      "dependencies": {
+        "@cardano-ogmios/client": "6.5.0",
+        "@cardano-ogmios/schema": "6.5.0",
+        "@cardano-sdk/crypto": "~0.1.29",
+        "@cardano-sdk/util": "~0.15.4",
+        "@cardano-sdk/util-dev": "~0.22.0",
+        "@foxglove/crc": "^0.0.3",
+        "@scure/base": "^1.1.1",
+        "fraction.js": "4.0.1",
+        "ip-address": "^9.0.5",
+        "lodash": "^4.17.21",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.4.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cardano-sdk/key-management/node_modules/@cardano-sdk/key-management": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/key-management/-/key-management-0.24.1.tgz",
+      "integrity": "sha512-kW+83duwNnZfrodfA8BoB73RMZJWrBXXNTOYcNoT98nfYc6YUHyB39K4FAp4aS5+s8iHQqbB4nsOJrlzzqwmFA==",
+      "dependencies": {
+        "@cardano-sdk/core": "~0.39.2",
+        "@cardano-sdk/crypto": "~0.1.30",
+        "@cardano-sdk/dapp-connector": "~0.12.35",
+        "@cardano-sdk/util": "~0.15.5",
+        "@emurgo/cardano-message-signing-nodejs": "^1.0.1",
+        "bip39": "^3.0.4",
+        "chacha": "^2.1.0",
+        "get-random-values": "^2.0.0",
+        "lodash": "^4.17.21",
+        "pbkdf2": "^3.1.2",
+        "rxjs": "^7.4.0",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardano-sdk/key-management/node_modules/@cardano-sdk/key-management/node_modules/@cardano-sdk/core": {
+      "version": "0.39.2",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.39.2.tgz",
+      "integrity": "sha512-/F4s2T3s1Go1CBsxQXufCLmKjUwm2g5JWqZMoFKtmBNLwhRtKAISYaj9hZoWbCS3+qJ7+04QOojwgqwG+Nb7Sg==",
+      "dependencies": {
+        "@biglup/is-cid": "^1.0.3",
+        "@cardano-ogmios/client": "6.5.0",
+        "@cardano-ogmios/schema": "6.5.0",
+        "@cardano-sdk/crypto": "~0.1.30",
+        "@cardano-sdk/util": "~0.15.5",
+        "@foxglove/crc": "^0.0.3",
+        "@scure/base": "^1.1.1",
+        "fraction.js": "4.0.1",
+        "ip-address": "^9.0.5",
+        "lodash": "^4.17.21",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.4.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cardano-sdk/key-management/node_modules/@cardano-sdk/util-dev": {
+      "version": "0.22.8",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/util-dev/-/util-dev-0.22.8.tgz",
+      "integrity": "sha512-/QV8x8Qf2mIOlb5UAF4JZ7AeRHmpfw9H8E8rT6revSt9wdLYScnXyGEuYtogv/DfJBzSaKdyLl7Adfstj3qeYw==",
+      "dependencies": {
+        "@cardano-sdk/core": "~0.39.2",
+        "@cardano-sdk/crypto": "~0.1.30",
+        "@cardano-sdk/key-management": "~0.24.1",
+        "@cardano-sdk/util": "~0.15.5",
+        "@types/dockerode": "^3.3.8",
+        "axios": "^1.7.4",
+        "delay": "^5.0.0",
+        "dockerode": "^3.3.1",
+        "dockerode-utils": "^0.0.7",
+        "envalid": "^7.3.1",
+        "get-port-please": "^2.5.0",
+        "json-bigint": "^1.0.0",
+        "k6": "^0.0.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.4.0",
+        "ts-log": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardano-sdk/key-management/node_modules/@cardano-sdk/util-dev/node_modules/@cardano-sdk/core": {
+      "version": "0.39.2",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.39.2.tgz",
+      "integrity": "sha512-/F4s2T3s1Go1CBsxQXufCLmKjUwm2g5JWqZMoFKtmBNLwhRtKAISYaj9hZoWbCS3+qJ7+04QOojwgqwG+Nb7Sg==",
+      "dependencies": {
+        "@biglup/is-cid": "^1.0.3",
+        "@cardano-ogmios/client": "6.5.0",
+        "@cardano-ogmios/schema": "6.5.0",
+        "@cardano-sdk/crypto": "~0.1.30",
+        "@cardano-sdk/util": "~0.15.5",
+        "@foxglove/crc": "^0.0.3",
+        "@scure/base": "^1.1.1",
+        "fraction.js": "4.0.1",
+        "ip-address": "^9.0.5",
+        "lodash": "^4.17.21",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.4.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cardano-sdk/key-management/node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@cardano-sdk/util": {
       "version": "0.15.5",
       "resolved": "https://registry.npmjs.org/@cardano-sdk/util/-/util-0.15.5.tgz",
@@ -2314,6 +2700,123 @@
       },
       "engines": {
         "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardano-sdk/util-dev": {
+      "version": "0.21.8",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/util-dev/-/util-dev-0.21.8.tgz",
+      "integrity": "sha512-RQszBXOuqZn6GDH9C7hshHUWpJorV7o72bkgpMa/QhDJDul7sEA22+YeK41ssDDkRzfYzTEZqqhLpCKfnOg0ZA==",
+      "dependencies": {
+        "@cardano-sdk/core": "~0.35.4",
+        "@cardano-sdk/crypto": "~0.1.28",
+        "@cardano-sdk/key-management": "~0.21.1",
+        "@cardano-sdk/util": "~0.15.4",
+        "@types/dockerode": "^3.3.8",
+        "axios": "^0.28.0",
+        "delay": "^5.0.0",
+        "dockerode": "^3.3.1",
+        "dockerode-utils": "^0.0.7",
+        "envalid": "^7.3.1",
+        "get-port-please": "^2.5.0",
+        "json-bigint": "^1.0.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.4.0",
+        "ts-log": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardano-sdk/util-dev/node_modules/@cardano-ogmios/client": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@cardano-ogmios/client/-/client-6.3.0.tgz",
+      "integrity": "sha512-nWaZ76n/R+p8nxBfRCetOuoDH8o5QToL5zWhRUu9EwHDJqM/0rzvYEk9JYCikAcVlC1qt6+3CcG4nCpG0dsptw==",
+      "dependencies": {
+        "@cardano-ogmios/schema": "6.3.0",
+        "@cardanosolutions/json-bigint": "^1.0.1",
+        "@types/json-bigint": "^1.0.1",
+        "bech32": "^2.0.0",
+        "cross-fetch": "^3.1.4",
+        "fastq": "^1.11.0",
+        "isomorphic-ws": "^4.0.1",
+        "nanoid": "^3.1.31",
+        "ts-custom-error": "^3.2.0",
+        "ws": "^7.4.6"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@cardano-sdk/util-dev/node_modules/@cardano-ogmios/schema": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@cardano-ogmios/schema/-/schema-6.3.0.tgz",
+      "integrity": "sha512-reM7NDYV4cgMAdFCzypoIuCVgSUfR9ztRMlk6p7k0cTeqUkbMfA83ps1FVkTDxzXxFjgM4EkhqoJyRjKIKRPQA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@cardano-sdk/util-dev/node_modules/@cardano-sdk/core": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.35.4.tgz",
+      "integrity": "sha512-FgNHOs9/kp8mqNagWkghn+Xfj0Wfr7HhBhxW92RZL2kKop7zyWlwhhXIZMdZvbHzqnAWhdIg2IYNb8j6IMI3yA==",
+      "dependencies": {
+        "@cardano-ogmios/client": "6.3.0",
+        "@cardano-ogmios/schema": "6.3.0",
+        "@cardano-sdk/crypto": "~0.1.28",
+        "@cardano-sdk/util": "~0.15.4",
+        "@cardano-sdk/util-dev": "~0.21.8",
+        "@foxglove/crc": "^0.0.3",
+        "@scure/base": "^1.1.1",
+        "fraction.js": "4.0.1",
+        "ip-address": "^9.0.5",
+        "lodash": "^4.17.21",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.4.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cardano-sdk/util-dev/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "node_modules/@cardano-sdk/util-dev/node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/@cardano-sdk/util-dev/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cardano-sdk/util/node_modules/bech32": {
@@ -3736,6 +4239,11 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
+    "node_modules/@emurgo/cardano-message-signing-nodejs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-message-signing-nodejs/-/cardano-message-signing-nodejs-1.0.1.tgz",
+      "integrity": "sha512-PoKh1tQnJX18f8iEr8Jk1KXxKCn9eqaSslMI1pyOJvYRJhQVDLCh0+9YReufjp0oFJIY1ShcrR+4/WnECVZUKQ=="
+    },
     "node_modules/@emurgo/cardano-serialization-lib-browser": {
       "version": "11.5.0",
       "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-11.5.0.tgz",
@@ -4896,6 +5404,14 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@noble/ed25519": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.1.0.tgz",
+      "integrity": "sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
@@ -5806,6 +6322,25 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "3.3.31",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.31.tgz",
+      "integrity": "sha512-42R9eoVqJDSvVspV89g7RwRqfNExgievLNWoHkg7NoWIqAmavIbgQBb4oc0qRtHkxE+I3Xxvqv7qVXFABKPBTg==",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.44.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.6.tgz",
@@ -6096,6 +6631,22 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.1.tgz",
+      "integrity": "sha512-ZIbEqKAsi5gj35y4P4vkJYly642wIbY6PqoN0xiyQGshKUGXR9WQjF/iF9mXBQ8uBKy3ezfsCkcoHKhd0BzuDA==",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
+      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -7139,6 +7690,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/asn1.js": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
@@ -7185,8 +7744,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -7206,6 +7764,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+      "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -7591,6 +8159,14 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -7670,6 +8246,39 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
       "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/blake-hash": {
       "version": "2.0.0",
@@ -8033,6 +8642,15 @@
         "node": ">=6.14.2"
       }
     },
+    "node_modules/buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -8166,6 +8784,51 @@
         "node": ">=16"
       }
     },
+    "node_modules/chacha": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chacha/-/chacha-2.1.0.tgz",
+      "integrity": "sha512-FhVtqaZOiHlOKUkAWfDlJ+oe/O8iPQbCC0pFXJqphr4YQBCZPXa8Mv3j35+W4eWFWCoTUcW2u5IWDDkknygvVA==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^1.0.33"
+      },
+      "optionalDependencies": {
+        "chacha-native": "^2.0.0"
+      }
+    },
+    "node_modules/chacha-native": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/chacha-native/-/chacha-native-2.0.3.tgz",
+      "integrity": "sha512-93h+osfjhR2sMHAaapTLlL/COoBPEZ6upicPBQ4GfUyadoMb8t9/M0PKK8kC+F+DEA/Oy3Kg9w3HzY3J1foP3g==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.1",
+        "nan": "^2.4.0"
+      }
+    },
+    "node_modules/chacha/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
+    "node_modules/chacha/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/chacha/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -8222,6 +8885,11 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
@@ -8379,7 +9047,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -8602,8 +9269,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -8618,6 +9284,20 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/crc": {
@@ -9195,7 +9875,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -9310,6 +9989,46 @@
         "node": ">=6"
       }
     },
+    "node_modules/docker-modem": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.8.tgz",
+      "integrity": "sha512-f0ReSURdM3pcKPNS30mxOHSbaFLcknGmQjwSfmbcdOw1XWKXVhukM3NJHhr7NpY9BIyyWQb0EBo3KQvvuU5egQ==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.11.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.5.tgz",
+      "integrity": "sha512-/0YNa3ZDNeLr/tSckmD69+Gq+qVNhvKfAHNeZJBnp7EOP6RGKV8ORrJHkUn20So5wU+xxT7+1n5u8PjHbfjbSA==",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "docker-modem": "^3.0.0",
+        "tar-fs": "~2.0.1"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode-utils": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/dockerode-utils/-/dockerode-utils-0.0.7.tgz",
+      "integrity": "sha512-vxMjHFl54CZ/XNtaaBgeaYchIY1F79nD3ymZkiM1HC5cL9SRAFvsJfplqobsT3cfbLJPaUlHW1nuVJEnlu+SOg==",
+      "dependencies": {
+        "@types/node": "^8.0.13"
+      }
+    },
+    "node_modules/dockerode-utils/node_modules/@types/node": {
+      "version": "8.10.66",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -9354,6 +10073,11 @@
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "node_modules/domain-browser": {
       "version": "4.23.0",
@@ -9532,6 +10256,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
@@ -9553,6 +10285,22 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/envalid": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/envalid/-/envalid-7.3.1.tgz",
+      "integrity": "sha512-KL1YRwn8WcoF/Ty7t+yLLtZol01xr9ZJMTjzoGRM8NaSU+nQQjSWOQKKJhJP2P57bpdakJ9jbxqQX4fGTOicZg==",
+      "dependencies": {
+        "tslib": "2.3.1"
+      },
+      "engines": {
+        "node": ">=8.12"
+      }
+    },
+    "node_modules/envalid/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/envinfo": {
       "version": "7.11.0",
@@ -11042,10 +11790,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
-      "dev": true,
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
@@ -11073,7 +11820,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -11151,6 +11897,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fs-extra": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
@@ -11164,6 +11915,11 @@
       "engines": {
         "node": ">=14.14"
       }
+    },
+    "node_modules/fs-memo": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fs-memo/-/fs-memo-1.2.0.tgz",
+      "integrity": "sha512-YEexkCpL4j03jn5SxaMHqcO6IuWuqm8JFUYhyCep7Ao89JIYmB8xoKhK7zXXJ9cCaNXpyNH5L3QtAmoxjoHW2w=="
     },
     "node_modules/fs-monkey": {
       "version": "1.0.5",
@@ -11275,6 +12031,25 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-port-please": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-2.6.1.tgz",
+      "integrity": "sha512-4PDSrL6+cuMM1xs6w36ZIkaKzzE0xzfVBCfebHIJ3FE8iB9oic/ECwPw3iNiD4h1AoJ5XLLBhEviFAVrZsDC5A==",
+      "dependencies": {
+        "fs-memo": "^1.2.0"
+      }
+    },
+    "node_modules/get-random-values": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/get-random-values/-/get-random-values-2.1.0.tgz",
+      "integrity": "sha512-q2yOLpLyA8f9unfv2LV8KVRUFeOIrQVS5cnqpbv6N+ea9j1rmW5dFKj/2Q7CK3juEfDYQgPxGt941VJcmw0jKg==",
+      "dependencies": {
+        "global": "^4.4.0"
+      },
+      "engines": {
+        "node": "14 || 16 || >=18"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -11340,6 +12115,15 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -11533,6 +12317,15 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hex-encoding": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hex-encoding/-/hex-encoding-2.0.2.tgz",
+      "integrity": "sha512-NhclxbCmF1NTU9mE0GYEkUrFX5VvnfiHrzcqGbsQJcLT33rE/yqBB+U1bHDuLk86AQyN/hsr+Q/sX3jRxmarhg==",
+      "dependencies": {
+        "node-buffer-encoding": "^1.0.1",
+        "uint8-encoding": "^2.0.0"
       }
     },
     "node_modules/hey-listen": {
@@ -14556,6 +15349,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -14678,6 +15479,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/k6": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/k6/-/k6-0.0.0.tgz",
+      "integrity": "sha512-GAQSWayS2+LjbH5bkRi+pMPYyP1JSp7o+4j58ANZ762N/RH/SdlAT3CHHztnn8s/xgg8kYNM24Gd2IPo9b5W+g=="
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -15066,7 +15872,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -15075,7 +15880,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -15090,6 +15894,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -15122,6 +15934,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -15214,6 +16031,11 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+    },
+    "node_modules/node-buffer-encoding": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/node-buffer-encoding/-/node-buffer-encoding-1.0.2.tgz",
+      "integrity": "sha512-v2QFjf04xWb5Q7cyzbi8qEwe2vw2xJBXT7+pMOLA02+KJZlcJ/6syFYiH96ClXKfOG/kyBeysAuewJ7zfAUYKQ=="
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -18572,7 +19394,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -19262,6 +20083,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -19285,6 +20111,15 @@
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -20848,11 +21683,33 @@
         "wbuf": "^1.7.3"
       }
     },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/ssh2": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
+      "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.9",
+        "nan": "^2.18.0"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -21186,6 +22043,32 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+      "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -21731,6 +22614,11 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
     },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -21880,6 +22768,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/uint8-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uint8-encoding/-/uint8-encoding-2.0.0.tgz",
+      "integrity": "sha512-MQcY+mEuLoHBqAawasWrFbZx1SqUoFU/wVYNGO6lsIxczeO+cNjA1djYHQM3GWU3SaEhKTfG3Z5cE2r+zR6tNw=="
     },
     "node_modules/uint8-varint": {
       "version": "2.0.4",
@@ -22319,6 +23212,11 @@
         "node": ">=14",
         "npm": ">=6.12.0"
       }
+    },
+    "node_modules/webextension-polyfill": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz",
+      "integrity": "sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ=="
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -22782,8 +23680,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "NODE_ENV=test jest"
   },
   "dependencies": {
+    "@blaze-cardano/sdk": "^0.1.32",
     "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.3",
     "@cardano-sdk/core": "^0.39.2",
     "@chakra-ui/css-reset": "^2.3.0",


### PR DESCRIPTION
We still have some reports of input selection failures in wallets with many assets. Nami currently uses CML for input selection, but it seems it doesn't work very well with wallet with many assets. This PR replaces CML with Blaze for wallet built transactions.