### PR TITLE
fix: replace buggy Cardano address validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nami-wallet",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nami-wallet",
-      "version": "3.8.3",
+      "version": "3.8.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@blaze-cardano/sdk": "^0.1.32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nami-wallet",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "description": "Maintained by IOG",
   "license": "Apache-2.0",
   "repository": {

--- a/src/api/extension/index.js
+++ b/src/api/extension/index.js
@@ -39,7 +39,7 @@ import TrezorConnect from '@trezor/connect-web';
 import AssetFingerprint from '@emurgo/cip14-js';
 import { isAddress } from 'web3-validator';
 import { milkomedaNetworks } from '@dcspark/milkomeda-constants';
-import { Serialization } from '@cardano-sdk/core';
+import { Cardano, Serialization } from '@cardano-sdk/core';
 import { Blaze, Blockfrost } from '@blaze-cardano/sdk';
 import provider from '../../config/provider';
 import { WebWallet } from '@blaze-cardano/wallet';
@@ -676,32 +676,16 @@ export const bytesAddressToBinary = (bytes) =>
   bytes.reduce((str, byte) => str + byte.toString(2).padStart(8, '0'), '');
 
 export const isValidAddress = async (address) => {
-  await Loader.load();
   const network = await getNetwork();
-  try {
-    const addr = Loader.Cardano.Address.from_bech32(address);
-    if (
-      (addr.network_id() === 1 && network.id === NETWORK_ID.mainnet) ||
-      (addr.network_id() === 0 &&
-        (network.id === NETWORK_ID.testnet ||
-          network.id === NETWORK_ID.preview ||
-          network.id === NETWORK_ID.preprod))
-    )
-      return addr.to_raw_bytes();
-    return false;
-  } catch (e) {}
-  try {
-    const addr = Loader.Cardano.ByronAddress.from_base58(address);
-    if (
-      (addr.network_id() === 1 && network.id === NETWORK_ID.mainnet) ||
-      (addr.network_id() === 0 &&
-        (network.id === NETWORK_ID.testnet ||
-          network.id === NETWORK_ID.preview ||
-          network.id === NETWORK_ID.preprod))
-    )
-      return addr.to_address().to_raw_bytes();
-    return false;
-  } catch (e) {}
+  const addr = Cardano.Address.fromString(address)
+  if (
+      (addr.getNetworkId() === 1 && network.id === NETWORK_ID.mainnet) ||
+      (addr.getNetworkId() === 0 &&
+          (network.id === NETWORK_ID.testnet ||
+              network.id === NETWORK_ID.preview ||
+              network.id === NETWORK_ID.preprod))
+  )
+    return Buffer.from(addr.toBytes(), 'hex');
   return false;
 };
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Nami",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "description": "Maintained by IOG",
   "background": { "service_worker": "background.bundle.js" },
   "action": {


### PR DESCRIPTION
At some point the Byron address validation stopped working. Given there are no tests, I've just replaced the logic with a tested validator from the `cardano-js-sdk`. It's a minimal change, ignoring the wonky logic of a function named `isValid` returning either the address as a buffer, if valid, or `false`.

Test coverage inherited from:
https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/core/test/Cardano/Address/Address.test.ts