### PR TITLE
fix: withdrawal transaction now always nominate at least one input

### DIFF
--- a/src/ui/app/components/transactionBuilder.jsx
+++ b/src/ui/app/components/transactionBuilder.jsx
@@ -220,7 +220,8 @@ const TransactionBuilder = React.forwardRef(({ onConfirm }, ref) => {
       withdrawRef.current.openModal(account.index);
       const protocolParameters = await initTx();
       try {
-        const tx = await withdrawalTx(account, delegation, protocolParameters);
+        const utxos = await getUtxos();
+        const tx = await withdrawalTx(account, delegation, protocolParameters, utxos);
         setData({
           pool: { ...poolDefaultValue },
           tx,


### PR DESCRIPTION
Withdrawals on Nami were failing if the rewards were enough to cover the fees as tx builder was not picking up any extra inputs (transactions without inputs are invalid).

This change makes sure the transaction always spends at least one input.