### PR TITLE
fix: stop injecting Sentry client into content scripts

### DIFF
--- a/src/features/sentry.js
+++ b/src/features/sentry.js
@@ -21,7 +21,7 @@ Sentry.init({
   // A tracesSampleRate of 0.05 and profilesSampleRate of 0.05 results in 2.5% of
   // transactions being profiled (0.05*0.05=0.0025)
 
-  // Capture Replay for 0.5% of all sessions,
+  // Capture Replay for 0.05% of all sessions,
   replaysSessionSampleRate: 0.005,
   // ...plus for 100% of sessions with an error
   replaysOnErrorSampleRate: 1.0,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,15 +80,9 @@ var options = {
       path.join(__dirname, 'src', 'ui', 'app', 'tabs', 'trezorTx.jsx')
     ),
     background: path.join(__dirname, 'src', 'pages', 'Background', 'index.js'),
-    contentScript: withMaybeSentry(
-      path.join(__dirname, 'src', 'pages', 'Content', 'index.js')
-    ),
-    injected: withMaybeSentry(
-      path.join(__dirname, 'src', 'pages', 'Content', 'injected.js')
-    ),
-    trezorContentScript: withMaybeSentry(
-      path.join(__dirname, 'src', 'pages', 'Content', 'trezorContentScript.js')
-    ),
+    contentScript: path.join(__dirname, 'src', 'pages', 'Content', 'index.js'),
+    injected: path.join(__dirname, 'src', 'pages', 'Content', 'injected.js'),
+    trezorContentScript: path.join(__dirname, 'src', 'pages', 'Content', 'trezorContentScript.js'),
   },
   chromeExtensionBoilerplate: {
     notHotReload: ['contentScript', 'devtools', 'injected'],


### PR DESCRIPTION
This is producing a massive number of rejected transactions in Sentry. We shouldn't be concerned with the webpage unhandled errors, except for DApp connection errors, which is more challenging to intercept.